### PR TITLE
Removed Duckduckgo

### DIFF
--- a/AdblockVPNGuide.md
+++ b/AdblockVPNGuide.md
@@ -420,8 +420,7 @@
 ## ▷ Search Engines
 
 * **[Search Engine Party](https://searchengine.party/)** - Privacy Search Engine Comparisons
-* **[DuckDuckGo](https://duckduckgo.com/)** - [Shortcuts](https://duckduckgo.com/bang)
-* [searx](https://asciimoo.github.io/searx/) - [Instances](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/storage#wiki_searx_instances) / [Desktop](https://notabug.org/CYBERDEViL/searx-qt)
+* **[searx](https://asciimoo.github.io/searx/)** - [Instances](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/storage#wiki_searx_instances) / [Desktop](https://notabug.org/CYBERDEViL/searx-qt)
 * [Qwant](https://www.qwant.com/)
 * [Swisscows](https://swisscows.com/)
 * [Metager](https://metager.org/)


### PR DESCRIPTION
Duckduckgo is not a private nor free search engine, since it begun censoring Russian searches. Now, they are censoring pirate sites and youtube-dl.
https://childrenshealthdefense.org/defender/duckduckgo-censorship-destroys-brand/
https://torrentfreak.com/duckduckgo-removes-pirate-sites-and-youtube-dl-from-its-search-results-220415/