### PR TITLE
Updated links in the Non-English (German) section

### DIFF
--- a/docs/non-english.md
+++ b/docs/non-english.md
@@ -414,8 +414,9 @@
 
 ## ▷ Downloading / Herunterladen
 
+* [Usenet DE Guide](https://github.com/PCJones/usenet-guide) - best Usenet guide for german content and [Radarr + Sonarr DE Guide](https://github.com/PCJones/radarr-sonarr-german-dual-language/blob/main/GERMAN_DUAL_LANGUAGE_GUIDE_GER.md) - includes tweaking instructions for german content and is written by the same person / [Discord](https://discord.com/invite/pZrrMcJMQM)
 * [Crawli](https://crawli.net/) - Download Search
-* [ArchivX](https://www.archivx.to/) or [StartSeite](https://startseite.to/) - Warez Lists
+* [ArchivX](https://www.archivx.to/), [StartSeite](https://startseite.to/) or [BestOfLinks](http://bestoflinks.synology.me/) - Warez Lists
 * [DarkLight](https://board.darklight.to/) - Video / Audio / ROMs / Books / Magazines / NSFW
 * [Warez-World](https://warez-world.org/) - Video / Audio / Books / Magazines / NSFW
 * [Goldesel](https://goldesel.bz/) - Video / Audio / NSFW
@@ -433,14 +434,14 @@
 
 ## ▷ Streaming
 
-* ⭐ **[Braflix](https://www.braflix.gd/)** - Movies / TV / Anime / Dub / 4K / 1080p
+* ⭐ **[Kinoger](https://kinoger.com/)** - Movies / TV / 1080p
 * ⭐ **[HDFilme](https://hdfilme.plus/)** - Movies / TV / Anime / Dub / 1080p
 * ⭐ **[Kinoking](https://kinoking.cc/)** - Movies / TV / Anime / Dub / 1080p
 * ⭐ **[Kinokiste](https://kinokiste.live/)** - Movies / TV / Dub / 1080p
-* [streamkiste](https://streamkiste.taxi/) - Movies / TV / Dub / 1080p
+* [Braflix](https://www.braflix.gd/) - Movies / TV / Anime / Dub / 4K / 1080p
+* [Streamkiste](https://streamkiste.tv/), [2](https://streamkiste.taxi/) - Movies / TV / Dub / 1080p
 * [FilmPalast](https://filmpalast.sx/), [2](https://filmpalast.info/) - Movies / TV / Dub / 1080p
-* [Kinoger](https://kinoger.com/) - Movies / TV / 1080p
-* [Megakino](https://megakino.org/) - Movies / TV / Dub / 720p
+* [Megakino](https://megakino.onl/), [2](https://megakino.org/) - Movies / TV / Dub / 720p
 * [StreamCloud](https://streamcloud.sx/) - Movies / TV / 720p
 * [Kinos](https://www.kinos.to/) - Movies / TV / Dub / 720p
 * [xCine](https://xcine.ru/) - Movies / TV / Dub / 720p


### PR DESCRIPTION
## Description
- added the best Usenet Guide for german content by PCJones (and his Radarr + Sonar guide tweaked for german content) and linked to to his Discord Server
- added BestOfLinks to the Warez Lists
- unstarred Braflix
- starred Kinoger
- added 2nd Streamkiste Link
- added 2nd Megakino Link
## Context
- The Usenet Guide is very helpful, and the Discord server is a great resource.
- BestOfLinks was added for completeness.
- I’ve never seen a German audio stream working on Braflix. I would remove it from the German content list altogether, as it essentially lacks any German content.
- Starred Kinoger as it is my go-to site (it has an easy-to-understand layout, is optimized for mobile, offers 1080p for everything, and has a large selection of content, also its unique and no copy like most of the site).
- The additional Streamkiste and Megakino links were added for completeness. These sites are often copied, and I have added (what I know as) the original links:
  - Streamkiste.tv
  - Megakino.onl

## Types of changes
- [ ] Bad / Deleted sites removal
- [ ] Grammar / Markdown fixes 
- [x] Content addition (sites, projects, tools, etc.)
- [ ] New Wiki section

## Checklist:
- [x] I have read the [contribution guide](https://fmhy.net/other/contributing).
- [x] I have made sure to [search](https://api.fmhy.net/single-page) before making any changes. 
- [x] My code follows the code style of this project.
