### PR TITLE
added "Letmefix Browser" extension to the Tab Manager list

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -1032,6 +1032,7 @@
 
 * ⭐ **[Sidebery](https://github.com/mbnuqw/sidebery)**
 * ⭐ **[Simple Tab Groups](https://github.com/drive4ik/simple-tab-groups)**
+* ⭐ **[Letmefix Browser](https://letmefix.io/browser)**
 
 [OneTab](https://www.one-tab.com/), [Tab Center Reborn](https://framagit.org/ariasuni/tabcenter-reborn), [Tab Stash](https://josh-berry.github.io/tab-stash/), [Tab Butler](https://tabbutler.netlify.app/), [One Tab Group](https://www.onetab.group/), [TreeStyleTabs](https://github.com/piroor/treestyletab)
 


### PR DESCRIPTION
## Description
Added "Letmefix browser" to the tab manager list

## Context
- Added "Letmefix browser" to the tab manager list
- Its a tab manager with many tab managin utilities
- Search and switch tabs
- Manage tab groups and pages

## Types of changes
- Content addition

## Checklist:
- [x] I have read the [contribution guide](https://fmhy.net/other/contributing).
- [x] I have made sure to [search](https://api.fmhy.net/single-page) before making any changes. 
- [x] My code follows the code style of this project.
