### PR TITLE
Edited SoulSeek link

### DIFF
--- a/docs/linuxguide.md
+++ b/docs/linuxguide.md
@@ -356,7 +356,7 @@ Linux Gaming Guide
 ## ▷ Linux Internet
 
 * ⭐ **[qBittorrent](https://github.com/qbittorrent/qBittorrent/wiki/Installing-qBittorrent#linux)** / [Tools](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/storage#wiki_qbitorrent_tools), **[rTorrent](https://rakshasa.github.io/rtorrent/)** / [2](https://github.com/rakshasa/rtorrent), [Fragments ](https://apps.gnome.org/en/Fragments/), [BitFlu](https://bitflu.workaround.ch/), [kTorrent](https://apps.kde.org/ktorrent/) / [2](https://invent.kde.org/network/ktorrent) - Linux Torrent Clients
-* ⭐ **[Soulseek](https://www.slsknet.org/SoulseekQt/Linux/SoulseekQt-2018-1-30-64bit-appimage.tgz)** - File Sharing App
+* ⭐ **[Soulseek](https://www.slsknet.org)** - File Sharing App
 * ⭐ **[Linux WiFi Hotspot](https://github.com/lakinduakash/linux-wifi-hotspot)** - Create WiFi Hotspots
 * [RuTorrent](https://github.com/Novik/ruTorrent) or [flood](https://flood.js.org/) - RTorrent Web Frontend / [Themes](https://github.com/artyuum/3rd-party-ruTorrent-Themes)
 * rTorrent Tools - [Extended](http://rtorrent-ps.readthedocs.io/) / [Tools](https://pyrocore.readthedocs.org/) / [GitHub](https://github.com/pyroscope/pyrocore) / [Mods](https://calomel.org/rtorrent_mods.html)


### PR DESCRIPTION
## Description
Changed the link for the Soulseek file sharing app from a download link to the index link

## Context
Clicking the link will currently just directly download the linux version of the app, it won't even bring you to the website or anything. This is bad for obvious reasons.

## Types of changes
- [ ] Bad / Deleted sites removal
- [ ] Grammar / Markdown fixes 
- [x] Content addition (sites, projects, tools, etc.)
- [ ] New Wiki section

## Checklist:
- [x] I have read the [contribution guide](https://fmhy.net/other/contributing).
- [x] I have made sure to [search](https://api.fmhy.net/single-page) before making any changes. 
- [x] My code follows the code style of this project.
