### PR TITLE
Added Geohub

### DIFF
--- a/docs/gamingpiracyguide.md
+++ b/docs/gamingpiracyguide.md
@@ -697,6 +697,7 @@
 ## ▷ GeoGuessr Games
 
 * ⭐ **[Globle](https://globle-game.com/)** - Country Hot-or-Cold Guessing Game
+* [Geohub](https://www.geohub.gg/) / [Github](https://github.com/benlikescode/geohub) / [Discord](https://discord.com/invite/9qdXWqgbrH) - Requires Google Maps API key
 * [Emily's GeoGuessr Tools](https://geo.emily.bz/) - GeoGuessr Tools
 * [GeoTips](https://geotips.net/) / [Discord](https://discord.gg/svhWzU7FMa), [Plonk It](https://www.plonkit.net/) or [Top Tricks](https://somerandomstuff1.wordpress.com/2019/02/08/geoguessr-the-top-tips-tricks-and-techniques/) - GeoGuessr Guides
 * [OpenGuessr](https://openguessr.com/) - Free GeoGuessr Alternative with Multiplayer


### PR DESCRIPTION
## Description
I added geohub a Free, open source geoguessr alternative unlike OpenGusser there is no ads the way they do this is you have to input your won google maps api key

## Context
There is only 1 actual geogusser alternative on FMHY that being open gusser. Geohub is a great free alternative with no ads unlike open gusser.

## Types of changes
<!--- What types of changes does your Pull Request introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bad / Deleted sites removal
- [ ] Grammar / Markdown fixes 
- [ X] Content addition (sites, projects, tools, etc.)
- [ ] New Wiki section

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply to this Pull Request. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X] I have read the [contribution guide](https://fmhy.net/other/contributing).
- [ X] I have made sure to [search](https://api.fmhy.net/single-page) before making any changes. 
- [ X] My code follows the code style of this project.
