### PR TITLE
Edit typo on AWTWA

### DIFF
--- a/docs/non-english.md
+++ b/docs/non-english.md
@@ -390,7 +390,7 @@
 * [animevostfr](https://animevostfr.tv/) - Anime / Sub / 1080p
 * [animeko](https://animeko.co/) - Anime / Sub / 1080p
 * [anime-sama](https://anime-sama.fr/) - Anime / Sub / 1080p
-* [AWTA](https://www.awtwa.site/) - Anime / Dub / 720p / [Discord](https://discord.gg/Pjs5p5TrEW)
+* [AWTWA](https://www.awtwa.site/) - Anime / Sub / 1080p / [Discord](https://discord.gg/Pjs5p5TrEW)
 * [VoirCartoon](https://voircartoon.com/) - Cartoons / Dub / 720p
 * [CatoonHub](https://catoonhub.com/) - Cartoons / Dub / 720p / [Discord](https://discord.com/invite/M7gRTuXc6d)
 * [Lesics](https://youtube.com/@LesicsFR) - Sabins Civil Engineering


### PR DESCRIPTION
Corrected a typo error and some information for AWTWA anime website

## Description
I corrected a typo in the name and the information of 720p, the site is 1080p for almost all the content, and it's sub not dub.

## Context
Not well written, so it's misunderstanding, same for quality & sub.

## Types of changes
- [ ] Bad / Deleted sites removal
- [x] Grammar / Markdown fixes 
- [ ] Content addition (sites, projects, tools, etc.)
- [ ] New Wiki section

## Checklist:
- [x] I have read the [contribution guide](https://fmhy.net/other/contributing).
- [x] I have made sure to [search](https://api.fmhy.net/single-page) before making any changes. 
- [x] My code follows the code style of this project.
