### PR TITLE
Add Kuroiru to Track / Discover Anime

### DIFF
--- a/docs/beginners-guide.md
+++ b/docs/beginners-guide.md
@@ -48,7 +48,7 @@ For mobile we recommend **[Cromite](https://github.com/uazo/cromite)**, **[Firef
 * **Streaming: [HiAnime](https://hianime.to/) / [Miruro](https://www.miruro.com/) / [AnimePahe](https://animepahe.ru/)**
 * **Downloading: [Tokyo Insider](https://www.tokyoinsider.com/) / [Hi10Anime](https://hi10anime.com/)**
 * **Torrenting: [Nyaa](https://nyaa.si/) / [Miru](https://miru.watch/)**
-* **Track / Discover: [MyAnimeList](https://myanimelist.net/) / [AniList](https://anilist.co/)**
+* **Track / Discover: [MyAnimeList](https://myanimelist.net/) / [AniList](https://anilist.co/) / [Kuroiru](https://kuroiru.co/)**
 
 ***
 


### PR DESCRIPTION
## Context
Kuroiru maybe the only anime tracking site that provides links to many streaming platforms including pirated streams directly to each episode page.
It's been around for a while, it's pretty reliable so far, and also keeps getting updated with new features that already quite comparable with other established tracking sites.
I think this site worth to put on Anime Track / Discover section.

side note: this site already mentioned `/videopiracyguide#anime-streaming` as part of CSE, which i think a bit out of place

## Types of changes
- [ ] Bad / Deleted sites removal
- [ ] Grammar / Markdown fixes 
- [x] Content addition (sites, projects, tools, etc.)
- [ ] New Wiki section

## Checklist:
- [x] I have read the [contribution guide](https://fmhy.net/other/contributing).
- [x] I have made sure to [search](https://api.fmhy.net/single-page) before making any changes. 
- [x] My code follows the code style of this project.
