### PR TITLE
calculatecgpa was replaced?

### DIFF
--- a/docs/edupiracyguide.md
+++ b/docs/edupiracyguide.md
@@ -1203,6 +1203,7 @@
 * [General Index](https://archive.org/details/GeneralIndex) - Article Metadata Mining Project
 * [Papertag](https://www.papertag.app/) - Attach Digital Content to Paper
 * [Graded](https://nightdreamgames.com/graded) - Grades Tracker / Android / [GitHub](https://github.com/NightDreamGames/Graded)
+* [GradesCalculator](https://calculatecgpa.com) - Calculate CGPA & GPA
 * [CalculateCGPA](https://cgpacalcs.com/) - Calculate GPA
 * [guIHelp](https://discord.gg/rgF9jY8CpH) - Bartleby, Quizlet, Coursehero & Scribd Discord Bot
 * [LearnedEasy](https://learnedeasy.com/) - Create Summaries / Quizzes from Books


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Hi, I noticed my website [calculatecgpa.com](https://www.calculatecgpa.com/) was replaced with [cgpacalcs.com](https://cgpacalcs.com/). I don't know why, but both websites help students calculate their grades.

## Context

[calculatecgpa.com](https://calculatecgpa.com) is a platform offering a range of calculators aimed at students worldwide. It helps users to calculate their CGPA, GPA, attendance, and convert their grades to a 4.0 scale.

## Types of changes
- [ ] Bad / Deleted sites removal
- [ ] Grammar / Markdown fixes 
- [x] Content addition (sites, projects, tools, etc.)
- [ ] New Wiki section

## Checklist:

- [x] I have read the [contribution guide](https://fmhy.net/other/contributing).
- [x] I have made sure to [search](https://api.fmhy.net/single-page) before making any changes. 
- [x] My code follows the code style of this project.
