### PR TITLE
Moved Whisky from Mac Apps to Mac Gaming and starred for better relevancy

### DIFF
--- a/docs/linuxguide.md
+++ b/docs/linuxguide.md
@@ -532,7 +532,6 @@ Linux Gaming Guide
 * [CloverBootloader](https://github.com/CloverHackyColor/CloverBootloader/) - Windows, Mac & Linux Bootloader / [Config](https://mackie100projects.altervista.org/)
 * [Boot Camp](https://support.apple.com/boot-camp) - Windows Bootloader / [DL Script](https://github.com/timsutton/brigadier)
 * [Docker OSX](https://github.com/sickcodes/Docker-OSX) - Mac VM in Docker
-* [Whisky](https://getwhisky.app/) - Wine Wrapper
 * [SwiftUI Win11](https://jinxiansen.github.io/Windows11/) - Windows 11 Desktop Client for macOS
 * [OrbStack](https://orbstack.dev/) - Docker Client
 * [Cider](https://cider.sh/) - Audio Players / Free Classic Version / [GitHub](https://github.com/ciderapp/Cider)
@@ -698,6 +697,7 @@ Linux Gaming Guide
 ## ▷ Mac Gaming
 
 * ⭐ **[Torrminatorr](https://forum.torrminatorr.com/)** - Mac Games
+* ⭐ **[Whisky](https://getwhisky.app/)** - Automated installer / wrapper for Apple Game Porting Toolkit and WINE designed for gaming
 * ⭐ **[AppleGamingWiki](https://applegamingwiki.com/)** - Mac Game Fixes / Compatibility
 * ⭐ **[Goldberg](https://github.com/inflation/goldberg_emulator)** - Steam Multiplayer Client Emulator
 * [SCNLOG](https://scnlog.me/) - Mac Games


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Moved the Whisky app from Mac Apps to Mac gaming as it's more relevant there.
- Starred Whisky app as it's the easiest implementation of the Apple Game Porting Toolkit and WINE for non-technical users and is free unlike Crossover

## Context

- While Whisky is technically part of the Mac Apps category, it fits much better in the Mac Gaming category, as it's an app that specifically helps Mac users play games designed for Windows
- Whisky's installer automatically installs and configures Apple's Game Porting Toolkit and WINE. In addition, it's also a much more friendly UI than other implementations

## Types of changes
- [ ] Bad / Deleted sites removal
- [ ] Grammar / Markdown fixes 
- [x] Content addition (sites, projects, tools, etc.)
- [ ] New Wiki section

## Checklist:
- [x] I have read the [contribution guide](https://fmhy.net/other/contributing).
- [x] I have made sure to [search](https://api.fmhy.net/single-page) before making any changes. 
- [x] My code follows the code style of this project.
