### PR TITLE
Modrinth + Curseforge Launchers

### DIFF
--- a/docs/audiopiracyguide.md
+++ b/docs/audiopiracyguide.md
@@ -107,6 +107,7 @@
 * ⭐ **[Reddit Music Player](https://reddit.musicplayer.io/)** - Subreddit Music Player
 * ⭐ **[SoundCloud](https://soundcloud.com/)** - User Made Songs / [Spotify Theme](https://userstyles.world/style/16767/) / [Dark Theme](https://github.com/huds0nx/soundcloud-luna)
 * ⭐ **[hate5six](https://hate5six.com/)** - Concert Recordings
+* ⭐ **[Newgrounds](https://www.newgrounds.com/audio)** - User Made Songs
 * [Spotify Web Client](https://open.spotify.com/) - Browser Music
 * [ArtistGrid](https://artistgrid.netlify.app/) - Browser Music
 * [Groovesharks](https://groovesharks.org/) - Browser Music

--- a/docs/gaming-tools.md
+++ b/docs/gaming-tools.md
@@ -531,6 +531,8 @@
 * [X Minecraft Launcher](https://xmcl.app/) - Launcher
 * [Salwyrr Launcher](https://www.salwyrr.com/) - Launcher / [Use Cracked Accounts](https://pastebin.com/ggcB7RNi)
 * [Ares](https://www.aresclient.com/) - Client
+* [Curseforge](https://www.curseforge.com/download/app) - Modpack Launcher
+* [Modrinth](https://modrinth.com/app) - Modpack Launcher / [Discord](https://discord.modrinth.com/)
 
 ***
 


### PR DESCRIPTION
btw [https://rentry.co/fmhy-invite](https://rentry.co/fmhy-invite) needs to be updated

## Description
Added modrinth and curseforge to gaming-tools#launchers

## Context
Because they are the main 2 modding platforms used

## Types of changes
<!--- What types of changes does your Pull Request introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bad / Deleted sites removal
- [ ] Grammar / Markdown fixes 
- [ x] Content addition (sites, projects, tools, etc.)
- [ ] New Wiki section

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply to this Pull Request. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have read the [contribution guide](https://fmhy.net/other/contributing).
- [x ] I have made sure to [search](https://api.fmhy.net/single-page) before making any changes. 
- [x ] My code follows the code style of this project.
