### PR TITLE
G.js (Maintained fork of SPWN)

### DIFF
--- a/docs/gaming-tools.md
+++ b/docs/gaming-tools.md
@@ -790,7 +790,7 @@ generate various codes codes for the Pokémon Mystery Dungeon series
 * [Globed](https://geode-sdk.org/mods/dankmeme.globed2/) - GD Multiplayer Mod
 * [GD Browser](https://gdbrowser.com/) - GD Level Browser
 * [GD Font Generator](https://gdcolon.com/gdfont) - Generate Custom GD Logos & Messages
-* [SPWN](https://spu7nix.net/spwn/#/) - GD Level Programming Language
+* [SPWN](https://spu7nix.net/spwn/#/) or [G.js](https://g-js-api.github.io/G.js/) - GD Level Programming Language
 * [GD Docs](https://wyliemaster.github.io/gddocs/) - GD Programming Documentation
 * [GD History](https://history.geometrydash.eu/) - GD Archival Project / [Downloader](https://github.com/Cvolton/GDHistory-Downloader)
 * [GMD Private Server](https://github.com/Cvolton/GMDprivateServer) - Private Server Maker

--- a/docs/gaming-tools.md
+++ b/docs/gaming-tools.md
@@ -790,7 +790,8 @@ generate various codes codes for the Pokémon Mystery Dungeon series
 * [Globed](https://geode-sdk.org/mods/dankmeme.globed2/) - GD Multiplayer Mod
 * [GD Browser](https://gdbrowser.com/) - GD Level Browser
 * [GD Font Generator](https://gdcolon.com/gdfont) - Generate Custom GD Logos & Messages
-* [SPWN](https://spu7nix.net/spwn/#/) or [G.js](https://g-js-api.github.io/G.js/) - GD Level Programming Language
+* [G.js](https://g-js-api.github.io/G.js/) - GD Level Programming Language
+* [SPWN](https://spu7nix.net/spwn/#/) - GD Level Programming Language
 * [GD Docs](https://wyliemaster.github.io/gddocs/) - GD Programming Documentation
 * [GD History](https://history.geometrydash.eu/) - GD Archival Project / [Downloader](https://github.com/Cvolton/GDHistory-Downloader)
 * [GMD Private Server](https://github.com/Cvolton/GMDprivateServer) - Private Server Maker

--- a/docs/gaming-tools.md
+++ b/docs/gaming-tools.md
@@ -790,8 +790,7 @@ generate various codes codes for the Pokémon Mystery Dungeon series
 * [Globed](https://geode-sdk.org/mods/dankmeme.globed2/) - GD Multiplayer Mod
 * [GD Browser](https://gdbrowser.com/) - GD Level Browser
 * [GD Font Generator](https://gdcolon.com/gdfont) - Generate Custom GD Logos & Messages
-* [G.js](https://g-js-api.github.io/G.js/) - GD Level Programming Language
-* [SPWN](https://spu7nix.net/spwn/#/) - GD Level Programming Language
+* [SPWN](https://spu7nix.net/spwn/#/) or [G.js](https://g-js-api.github.io/G.js/) - GD Level Programming Language
 * [GD Docs](https://wyliemaster.github.io/gddocs/) - GD Programming Documentation
 * [GD History](https://history.geometrydash.eu/) - GD Archival Project / [Downloader](https://github.com/Cvolton/GDHistory-Downloader)
 * [GMD Private Server](https://github.com/Cvolton/GMDprivateServer) - Private Server Maker


### PR DESCRIPTION
## Description
SPWN hasnt been updated in years and G.js is a fork of it being maintained just put G.js in the geometry dash gaming tools section
I think SPWN should be removed because its not maintained but I didnt remove it

## Context
Because SPWN doesnt get updated

## Types of changes
<!--- What types of changes does your Pull Request introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bad / Deleted sites removal
- [ ] Grammar / Markdown fixes 
- [x] Content addition (sites, projects, tools, etc.)
- [ ] New Wiki section

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply to this Pull Request. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://fmhy.net/other/contributing).
- [x] I have made sure to [search](https://api.fmhy.net/single-page) before making any changes. 
- [x] My code follows the code style of this project.
