### PR TITLE
Remove mentions of deprecated paths & files

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -9,7 +9,7 @@ There are multiple ways you can contribute to this repository:
 ## Submitting a Link
 
 > [!NOTE]
-> If you haven't tested the link you'd like to submit, especially if it's a DDL site, please open an **[Issue](https://github.com/fmhy/FMHYedit/issues)** or reach out to us on **[Discord](https://rentry.co/fmhy-invite)** rather than making a Pull Request.
+> If you haven't tested the link you'd like to submit, especially if it's a DDL site, please open an **[Issue](https://github.com/fmhy/edit/issues)** or reach out to us on **[Discord](https://rentry.co/fmhy-invite)** rather than making a Pull Request.
 
 1. Before submitting a link, please **[search](https://redd.it/105xraz)** to make sure it's not already in the wiki.
 
@@ -18,7 +18,7 @@ Please only use the store link if there's neither a site nor a Git repository av
 
 3. Always check to see if the site you'd like to submit has a Discord / Telegram server you can link with it.
 
-4. Find a suitable category for the link and then submit it by making a **[Pull Request](https://github.com/fmhy/FMHYedit/pulls)**. 
+4. Find a suitable category for the link and then submit it by making a **[Pull Request](https://github.com/fmhy/edit/pulls)**. 
 
 #### Don't Submit:
 
@@ -40,11 +40,11 @@ Don't post any hacks/exploits that give unfair advantages in multiplayer games.
 ## Reporting a Site
 
 > [!TIP]
-> If you want to make bigger changes to the wiki, such as debloating or restructuring a page/section, please discuss those changes with us via **[Discord](https://rentry.co/fmhy-invite)** before making a **[Pull Request](https://github.com/fmhy/FMHYedit/pulls)**.
+> If you want to make bigger changes to the wiki, such as debloating or restructuring a page/section, please discuss those changes with us via **[Discord](https://rentry.co/fmhy-invite)** before making a **[Pull Request](https://github.com/fmhy/edit/pulls)**.
 
 You can do one of the following:
 
-- Open an **[Issue](https://github.com/fmhy/FMHYedit/issues)** or a **[Pull Request](https://github.com/fmhy/FMHYedit/pulls)** and don't forget to explain why you think the site(s) in question should be removed, unstarred, and/or changed.
+- Open an **[Issue](https://github.com/fmhy/edit/issues)** or a **[Pull Request](https://github.com/fmhy/edit/pulls)** and don't forget to explain why you think the site(s) in question should be removed, unstarred, and/or changed.
 
 - Alternatively, you can reach out to us on **[Discord](https://rentry.co/fmhy-invite)** if you're unsure whether the site should be reported or if you'd like to discuss your report with more people.
 

--- a/.github/ISSUE_TEMPLATE/wiki.yml
+++ b/.github/ISSUE_TEMPLATE/wiki.yml
@@ -11,7 +11,7 @@ body:
       value: |
         ### Things to note
         * Anyone can suggest [changes or corrections](https://rentry.org/fmhyedit) to the wiki. Please read our [Contribution Guide](https://rentry.co/Contrib-Guide) before trying to add or remove anything.
-        * If you're adding a new site, please [search](https://raw.githubusercontent.com/fmhy/FMHYedit/main/single-page) (control + f) first to make sure we don't already have it.
+        * If you're adding a new site, please [search](https://raw.githubusercontent.com/fmhy/edit/main/single-page) (control + f) first to make sure we don't already have it.
         * Approved changes will be applied to the [site](https://fmhy.net) and all [🔒 backups](https://github.com/fmhy/FMHY/wiki/Backups).
         * You can send us stuff directly via [💬 Discord](https://rentry.co/fmhy-invite).
         * You can also check out our [website](https://fmhy.net) and the [posts](https://fmhy.net/posts) section to know about any major updates to the wiki.

--- a/.github/POST_TEMPLATE.md
+++ b/.github/POST_TEMPLATE.md
@@ -31,7 +31,7 @@ footer: true
 :::info
 These update threads only contains major updates. If you're interested
 in seeing all minor changes you can follow our
-[Commits Page](https://github.com/fmhy/FMHYedit/commits/main) on GitHub or
+[Commits Page](https://github.com/fmhy/edit/commits/main) on GitHub or
 [Updates Channel](https://redd.it/17f8msf) in Discord.
 :::
 

--- a/api/routes/single-page.ts
+++ b/api/routes/single-page.ts
@@ -17,7 +17,7 @@
 import { fetcher } from 'itty-fetcher'
 
 // Look inside tbe docs directory
-const GITHUB_REPO = 'https://api.github.com/repos/fmhy/FMHYEdit/contents/docs/'
+const GITHUB_REPO = 'https://api.github.com/repos/fmhy/edit/contents/docs/'
 const EXCLUDE_FILES = [
   'README.md',
   'index.md',

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -22,7 +22,7 @@ import { transforms } from './transformer'
 
 // @unocss-include
 
-const baseUrl = process.env.GITHUB_ACTIONS ? '/FMHYedit' : '/'
+const baseUrl = process.env.GITHUB_ACTIONS ? '/edit' : '/'
 export default defineConfig({
   title: 'FMHY',
   description: meta.description,
@@ -155,7 +155,7 @@ export default defineConfig({
       copyright: `© ${new Date().getFullYear()}, Estd 2018`
     },
     editLink: {
-      pattern: 'https://github.com/fmhy/FMHYEdit/edit/main/docs/:path',
+      pattern: 'https://github.com/fmhy/edit/edit/main/docs/:path',
       text: '📝 Edit this page'
     },
     outline: 'deep',

--- a/docs/.vitepress/constants.ts
+++ b/docs/.vitepress/constants.ts
@@ -28,7 +28,7 @@ export const meta = {
 
 export const commitRef =
   process.env.CF_PAGES && process.env.CF_PAGES_COMMIT_SHA
-    ? `<a href="https://github.com/fmhy/FMHYEdit/commit/${process.env.CF_PAGES_COMMIT_SHA
+    ? `<a href="https://github.com/fmhy/edit/commit/${process.env.CF_PAGES_COMMIT_SHA
     }">${process.env.CF_PAGES_COMMIT_SHA.slice(0, 8)}</a>`
     : 'dev'
 
@@ -110,7 +110,7 @@ export const search: DefaultTheme.Config['search'] = {
 }
 
 export const socialLinks: DefaultTheme.SocialLink[] = [
-  { icon: 'github', link: 'https://github.com/fmhy/FMHYEdit' },
+  { icon: 'github', link: 'https://github.com/fmhy/edit' },
   { icon: 'discord', link: 'https://rentry.co/fmhy-invite' },
   {
     ariaLabel: 'Reddit',

--- a/docs/.vitepress/transformer.ts
+++ b/docs/.vitepress/transformer.ts
@@ -214,10 +214,6 @@ export function transform(text: string): string {
       /https:\/\/www.reddit.com\/r\/FREEMEDIAHECKYEAH\/wiki\/img-tools/g,
       '/img-tools'
     )
-    .replace(
-      /https:\/\/github.com\/nbats\/FMHYedit\/blob\/main\/base64.md#/g,
-      '/base64/#'
-    )
     // Remove extra characters
     .replace(/\/#wiki_/g, '/#')
     .replace(/#wiki_/g, '/#')
@@ -250,7 +246,6 @@ export function transform(text: string): string {
       /\/storage\/#encode--decode_urls/g,
       '/storage/#encode--decode-urls'
     )
-    .replace(/\/base64\/#do-k-ument/g, '/base64/#do_k_ument')
     .replace(/\/devtools\/#machine-learning2/g, '/devtools/#machine-learning-1')
     .replace(/\/linuxguide#software-sites2/g, '/linuxguide#software-sites-1')
     .replace(/\/linuxguide#software_sites/g, '/linuxguide#software-sites')

--- a/docs/miscguide.md
+++ b/docs/miscguide.md
@@ -29,7 +29,7 @@
 * [National Archives](https://www.nationalarchives.gov.uk/webarchive/) - UK Government Site Archive
 * [The Hive Index](https://thehiveindex.com/) - Online Communities Index
 * [NetSplit](https://netsplit.de/) - IRC Channel Index
-* [Creative Commons](https://github.com/fmhy/FMHYedit/issues/1386#issuecomment-1906854653) - Creative Commons Content Sites
+* [Creative Commons](https://github.com/fmhy/edit/issues/1386#issuecomment-1906854653) - Creative Commons Content Sites
 * [Cyberlife](https://cyberpunk-life.neocities.org/) - Cyberpunk-Related Content / Sites Index
 * [sourcehut](https://sr.ht/) - Public Project Index
 * [ImageBoards](https://imageboards.net/) or [imageboards.json](https://github.com/ccd0/imageboards.json/blob/gh-pages/imageboards.json) - Imageboard Index

--- a/docs/posts/search.md
+++ b/docs/posts/search.md
@@ -29,7 +29,7 @@ Search engine hosted on old.fmhy.net
 
 ---
 
-### [GitHub Search](https://github.com/nbats/FMHY/search?q=&type=wikis)
+### [GitHub Search](https://github.com/fmhy/edit/search?q=&type=wikis)
 
 GitHub page search engine
 

--- a/docs/unsafesites.md
+++ b/docs/unsafesites.md
@@ -47,7 +47,7 @@ To easily see which sites are trusted, and which are unsafe, try the **[FMHY Saf
 * RSLOAD - Uploaded the same version of malwarebytes that got FileCR in trouble / [utorrent malware](https://i.ibb.co/QXrCfqQ/Untitled.png)
 * Taiwebs - Uploaded same version of [stardocks](https://pastebin.com/nPjVKYM9), [2](https://imgur.com/a/aeLoaTS) that got FileCR in trouble
 * Appnee - Not very careful with uploads, has multiple [unsafe activators](https://i.imgur.com/ZwjYBfr.png) / [2](https://i.ibb.co/7jKVtSR/ZwjYBfr.png)
-* AppValley / TutuBox / Ignition - History of [ddos attacks](https://github.com/nbats/FMHYedit/pull/307)
+* AppValley / TutuBox / Ignition - History of [ddos attacks](https://github.com/fmhy/edit/pull/307)
 * CNET / Download.com / ZDNET / Softonic - History of [adware](https://www.reddit.com/r/software/comments/9s7wyb/whats_the_deal_with_sites_like_cnet_softonic_and/e8mtye9/) / [2](https://ibb.co/tLc5KR7)
 * IObit - History of [Adware](https://www.malwarebytes.com/blog/detections/pup-iobit) and shady products
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Mainly to fix fmhy.github.io but removes all mentions of the old repo name (FMHYedit) and adjusts links pointing to the now non-existent base64.md page.

## Types of changes
<!--- What types of changes does your Pull Request introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bad / Deleted sites removal
- [x] Grammar / Markdown fixes 
- [ ] Content addition (sites, projects, tools, etc.)
- [ ] New Wiki section

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply to this Pull Request. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://fmhy.net/other/contributing).
- [x] I have made sure to [search](https://api.fmhy.net/single-page) before making any changes. 
- [x] My code follows the code style of this project.
