### PR TITLE
Add SpotifyAB to audiopiracyguide

### DIFF
--- a/docs/audiopiracyguide.md
+++ b/docs/audiopiracyguide.md
@@ -19,6 +19,7 @@
 
 * ⭐ **[SpotX](https://github.com/SpotX-Official/SpotX)** / [Telegram](https://t.me/SpotxCommunity)
 * ⭐ **[BlockTheSpot](https://github.com/mrpond/BlockTheSpot)** / [Discord](https://discord.gg/9tCNMFESuC)
+* ⭐ **[SpotifyAB](https://github.com/An0n-00/SpotifyAB)** / Client / Windows only / Based on SpotX
 * [BurntSushi](https://github.com/OpenByteDev/burnt-sushi)
 * [Spotify Adblock Guide](https://redd.it/yme7pf)
 * Spotify Mobile Adblock - [Android](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/android/#wiki_.25BA_android_audio) / [iOS](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/android/#wiki_.25BA_ios_audio)


### PR DESCRIPTION
This pull request includes a small change to the `docs/audiopiracyguide.md` file. The change adds a new entry for `SpotifyAB`, a Windows-only client based on SpotX.

## Description

* [`docs/audiopiracyguide.md`](diffhunk://#diff-84c97950a1b3b1a4e3d25da603bd811c82cafe3ec9b1107107b8f1b57c43cc10R22): Added a new entry for `SpotifyAB`, a Windows-only client based on SpotX.

## Context

SpotifyAB proiveds a WinForm Gui to SpotX. I just thought it would be worth mentioning.

## Types of changes
- [ ] Bad / Deleted sites removal
- [ ] Grammar / Markdown fixes 
- [X] Content addition (sites, projects, tools, etc.)
- [ ] New Wiki section

## Checklist:
- [X] I have read the [contribution guide](https://fmhy.net/other/contributing).
- [X] I have made sure to [search](https://api.fmhy.net/single-page) before making any changes. 
- [X] My code follows the code style of this project.
