### PR TITLE
Update videopiracyguide.md

### DIFF
--- a/docs/videopiracyguide.md
+++ b/docs/videopiracyguide.md
@@ -23,12 +23,13 @@
 * ⭐ **[Novafork](https://novafork.com/)** - Movies / TV / [Discord](https://discord.gg/XbDBBmh5FY) / [GitHub](https://github.com/fanlimgames/novafork)
 * ⭐ **[Nunflix](https://nunflix.org/)**, [2](https://nunflix-firebase.web.app/), [3](https://nunflix-ey9.pages.dev/), [4](https://nunflix-firebase.firebaseapp.com/) - Movies / TV / Anime / Auto-Next / [Docs](https://nunflix-info.vercel.app/), [2](https://nunflix-doc.pages.dev/) / [Discord](https://discord.gg/CXVyfhgn26)
 * [Smashystream](https://smashystream.xyz/), [2](https://flix.smashystream.xyz/), [3](https://smashystream.com/) or [smashy](https://smashy.stream/) - Movies / TV / Anime
+* [Zilla](https://zilla-xr.xyz/) - Movies / TV / [Discord](https://discord.gg/MCt2R9gqGb)
 * [CucuFlix](https://cucuflix.xyz/), [2](https://cucuflix.pro/) - Movies / TV / Anime / [Discord](https://discord.gg/tDKYeh9eQn)
 * [watch.lonelil](https://watch.lonelil.ru/) - Movies / TV / Anime / [Add Sources](https://watch.lonelil.ru/onboarding/extension) / [Discord](https://discord.com/invite/BKts6Jb5sA) / [Telegram](https://t.me/watchlonelil)
 * [Hexa](https://hexa.watch/) - Movies / TV / Anime / [Discord](https://discord.com/invite/fF7TwrjR6T)
 * [Heartive](https://heartive.pages.dev/) - Movies / TV / Anime
 * [Mapple.tv](https://mapple.tv/) - Movies / TV / Anime / [Discord](https://discord.gg/K5tQTjGjkt)
-* [Zilla-XR](https://zilla-xr.xyz/) - Movies / TV / Anime
+
 * [Flicker](https://flickermini.netlify.app/), [2](https://flickermini.pages.dev/), [3](https://flickeraddon.pages.dev/) -  Movies / TV / Anime
 * [stream fr](https://streamfr-bbjy.onrender.com/) - Movies / TV / Anime / [Discord](https://discord.com/invite/bqXhREHEDt) / [API](https://streamfr.onrender.com/docs) / [GitHub](https://github.com/bhaiaajo/streamfr)
 * [BrocoFlix](https://brocoflix.com/) - Movies / TV / Anime


### PR DESCRIPTION
Description
updated ZillaXR videopiracy guide

Context
last i checked zilla was still undergoing development, still is ,but the recent changes ,I believe should put it up there , also I 
updated the discord link and changed the shortname from Zilla-xr to Zilla  also removed the anime since its not yet supported fully as it focuses mainly on movies and TV shows 
also a lot of updates have been done though out the week , hopefully you also check them out 


Types of changes
 Bad / Deleted sites removal
 Grammar / Markdown fixes
 Content addition (sites, projects, tools, etc.)
 New Wiki section
Checklist:
 I have read the [contribution guide](https://fmhy.net/other/contributing).
 I have made sure to [search](https://api.fmhy.net/single-page) before making any changes.
 My code follows the code style of this project.
