### PR TITLE
Update audiopiracyguide.md

### DIFF
--- a/docs/audiopiracyguide.md
+++ b/docs/audiopiracyguide.md
@@ -728,6 +728,7 @@ https://www.ostmusic.org/
 * [Friture](https://friture.org/)
 * [Spectro](http://spectro.enpts.com/)
 * [Cambia](https://logs.musichoarders.xyz/) - CD Rip Log Checker
+* [OpenSoundMeter](https://opensoundmeter.com/) - Live sound PA tuning; SMAART alternative
 
 ***
 


### PR DESCRIPTION
Add OpenSoundMeter under Spectrum Analyzers

## Description
OpenSoundMeter is a FOSS alternative to the paid software SMAART which is commonly used in the live audio industry for tuning and measuring PA systems.

## Context
This software came out 4 years ago, but SMAART ($$$$) has been around for 20+ years. Not enough awareness of the free one.

## Types of changes
- [ ] Bad / Deleted sites removal
- [ ] Grammar / Markdown fixes 
- [x] Content addition (sites, projects, tools, etc.)
- [ ] New Wiki section

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply to this Pull Request. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://fmhy.net/other/contributing).
- [x] I have made sure to [search](https://api.fmhy.net/single-page) before making any changes. 
- [x] My code follows the code style of this project.
