### PR TITLE
Update Social Media Apps in iOS section of android-iosguide.md

### DIFF
--- a/docs/android-iosguide.md
+++ b/docs/android-iosguide.md
@@ -1203,7 +1203,7 @@ https://github.com/Akylas/alpimaps
 * ⭐ **[Enmity](https://github.com/enmity-mod/enmity)** / [Discord](https://discord.gg/rMdzhWUaGT) or [BunnyTweak](https://github.com/bunny-mod/BunnyTweak) - Discord Clients / [Extension](https://github.com/BillyCurtis/OpenDiscordSafariExtension)
 * ⭐ **[Winston](https://winston.cafe/)**, [Apollo Improved](https://github.com/JeffreyCA/Apollo-ImprovedCustomApi) or [OpenArtemis](https://apps.apple.com/app/id6473462587) - Reddit Clients
 * ⭐ **[Voyager](https://apps.apple.com/app/id6451429762) / [GitHub](https://github.com/aeharding/voyager)**, [Mlem](https://apps.apple.com/app/id6450543782) / [GitHub](https://github.com/mlemgroup/mlem) or [Thunder](https://apps.apple.com/app/id6450518497) / [GitHub](https://github.com/thunder-app/thunder) - Lemmy Clients
-* ⭐ **[tooot](https://tooot.app/)** or [Mastodon](https://apps.apple.com/app/id1571998974) - Mastodon Clients / [Improved Notifications](https://lucasggamerm.github.io/moshidon/) / [GitHub](https://github.com/LucasGGamerM/moshidon)
+* ⭐ **[Ice Cubes](https://apps.apple.com/us/app/ice-cubes-for-mastodon/id6444915884)** or [Mastodon](https://apps.apple.com/app/id1571998974) - Mastodon Clients
 * ⭐ **[BHTwitter](https://github.com/BandarHL/BHTwitter)** or [Twitter Branding](https://github.com/ghl3m0n/FuckElon) - Twitter Apps / [Extension](https://github.com/BandarHL/OpenTwitterSafariExtension)
 * [Openvibe](https://openvibe.social/) or [Sigma](https://apps.apple.com/app/id1594702352) - Combine Social Media Apps
 * [SNMessenger](https://github.com/NguyenASang/SNMessenger) - Facebook Messenger Tweak


### PR DESCRIPTION
## Changes

Edited Social Media Apps section of iOS section.

- Removed tooot as it is unmaintained (last update was a year ago, repository archived), replaced with Ice Cubes.

- Removed all mentions of Moshidon, as it is Android-only. It was also last updated 4 months ago.

---

- [x] Bad / Deleted sites removal
- [ ] Grammar / Markdown fixes 
- [x] Content addition (sites, projects, tools, etc.)
- [ ] New Wiki section

---

- [x] I have read the [contribution guide](https://fmhy.net/other/contributing).
- [x] I have made sure to [search](https://api.fmhy.net/single-page) before making any changes. 
- [x] My code follows the code style of this project.
