### PR TITLE
Clean up Audio Servers section of audiopiracyguide.md

### DIFF
--- a/docs/audiopiracyguide.md
+++ b/docs/audiopiracyguide.md
@@ -643,18 +643,17 @@
 
 ## ▷ Audio Servers
 
-* ⭐ **[AudioRelay](https://audiorelay.net/)** - Stream PC Audio to Phone
-* ⭐ **[iBroadcast](https://ibroadcast.com)**
+* ⭐ **[Navidrome](https://navidrome.org)**
 * ⭐ **[Airsonic](https://airsonic.github.io/)** or [Airsonic Advanced](https://github.com/airsonic-advanced/airsonic-advanced) / [Web UI](https://github.com/tamland/airsonic-refix)
 * ⭐ **[koel](https://koel.dev/)**
-* [Gelli](https://github.com/dkanada/gelli), [Feishin](https://github.com/jeffvli/feishin) or [Sonixd](https://github.com/jeffvli/sonixd) - Jellyfin Music Players
-* [SoundSync](https://soundsync.app/), [SnapCast](https://github.com/badaix/snapcast) or [SonoBus](https://sonobus.net/) - Sound System Sync
+* ⭐ **[iBroadcast](https://ibroadcast.com)**
+* ⭐ **[AudioRelay](https://audiorelay.net/)** - Stream PC Audio to Phone
+* [Audioling](https://github.com/audioling/audioling) or [Gelli](https://github.com/dkanada/gelli) (Android) - Jellyfin Music Players
+* [SnapCast](https://github.com/badaix/snapcast) or [SonoBus](https://sonobus.net/) - Sound System Sync
 * [mStream](https://mstream.io/)
 * [Mopidy](https://mopidy.com/)
-* [Auddly](https://auddly.app/)
 * [Black Candy](https://github.com/blackcandy-org/blackcandy)
 * [Music Player Daemon](https://www.musicpd.org/)
-* [Navidrome](https://www.navidrome.org/)
 * [Polaris](https://github.com/agersant/polaris)
 * [Gonic](https://github.com/sentriz/gonic)
 * [SynchronousAudioRouter](https://github.com/eiz/SynchronousAudioRouter)


### PR DESCRIPTION
## Changes

- Removed Feishin and Sonicxd from Audio servers - Both are currently being replaced with Audioling. Moved Gelli to the end and added `(Android)` to denote platform.

- Removed Soundsync as it hasn't been updated in 2 years.

- Moved AudioRelay to the bottom of the starred list, as it is only compatible with Android and is not a full audio server.

- Starred Navidrome, as it is a regularly maintained and highly advanced audio server.

- Moved iBroadcast down as it appears to be a proprietary service that is not self-hostable.

- Removed auddly as it hasn't been updated in 2 years.

---

## Types of changes

- [x] Bad / Deleted sites removal
- [ ] Grammar / Markdown fixes 
- [x] Content addition (sites, projects, tools, etc.)
- [ ] New Wiki section

## Checklist:

- [x] I have read the [contribution guide](https://fmhy.net/other/contributing).
- [x] I have made sure to [search](https://api.fmhy.net/single-page) before making any changes. 
- [x] My code follows the code style of this project.
