### PR TITLE
Update unsafesites.md

### DIFF
--- a/docs/unsafesites.md
+++ b/docs/unsafesites.md
@@ -35,6 +35,7 @@ To easily see which sites are trusted, and which are unsafe, try the **[FMHY Saf
 * KaranPC - Caught with malware multiple times
 * AliTPB / AliPak / b4tman - Caught with malware multiple times
 * FileCR - Caught with malware [multiple times](https://pastebin.com/ky5KMGz2)
+* Appdoze - Mirror of FileCR
 * FTUApps - Caught with [malware](https://redd.it/120xk62)
 * S0ft4PC / Portable4PC - Caught with malware
 * CrackingCity - Caught with [malware](https://tria.ge/241021-kfvhhsydpl/behavioral1) 


### PR DESCRIPTION
Added appdoze to unsafesites

Appdoze appears to be a rebranded Filecr, pushing the same malware as before.
Appdoze and Filecr use a very similar, perhaps a touch older crack for their Malwarebytes installs (see links section) that both push the exact same buttons.
They also use the exact same crack for IOBit Driver Booster Pro and Movavi Video Editor 2025.

Links section:

Filecr Mbam - https://filecr.com/windows/malwarebytes-premium - https://tria.ge/250113-r2t77sxqbj
Appdoze Mbam - https://appdoze.com/malwarebytes-premium - https://tria.ge/250113-ryfkmsxnfq

Filecr Iobit version.dll (crack) - https://filecr.com/windows/iobit-driver-booster -  https://www.virustotal.com/gui/file/4e12ff9a72b7c2357f46ef645400cb6311330ced73ee787244c85ba7c57e8c8e
Appdoze Iobit version.dll (crack) - https://appdoze.com/iobit-driver-booster-pro - https://www.virustotal.com/gui/file/4e12ff9a72b7c2357f46ef645400cb6311330ced73ee787244c85ba7c57e8c8e

Filecr Movavi Video Editor Plus - https://filecr.com/windows/movavi-video-editor - https://www.virustotal.com/gui/file/5c8cddfd9ada361203df797474920b1a2743a2cfc88a601455b3892f25b17ed1
Appdoze Movavi Video Editor Plus - https://appdoze.com/movavi-video-editor-plus-2025 - https://www.virustotal.com/gui/file/5c8cddfd9ada361203df797474920b1a2743a2cfc88a601455b3892f25b17ed1
