### PR TITLE
Update year

### DIFF
--- a/docs/miscguide.md
+++ b/docs/miscguide.md
@@ -792,7 +792,7 @@
 ## ▷ Tech Jobs
 
 * 🌐 **[Awesome Interview](https://github.com/DopplerHQ/awesome-interview-questions)** or [30-sec](https://30secondsofinterviews.org/) - Tech Interview Questions Indexes
-* 🌐 **[Summer 2025 Internships](https://github.com/SimplifyJobs/Summer2024-Internships)** - Tech Internships List / [Notifications](https://swelist.com/)
+* 🌐 **[Summer 2025 Internships](https://github.com/SimplifyJobs/Summer2025-Internships)** - Tech Internships List / [Notifications](https://swelist.com/)
 * 🌐 **[Free-Certifications](https://github.com/cloudcommunity/Free-Certifications)** - Free Certifications / Courses Index
 * 🌐 **[TheRemoteFreelancer](https://github.com/engineerapart/TheRemoteFreelancer)** - Remote Tech Jobs Index
 * ↪️ **[Learn Programming](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/edu/#wiki_.25BA_developer_learning)**

--- a/docs/miscguide.md
+++ b/docs/miscguide.md
@@ -792,7 +792,7 @@
 ## ▷ Tech Jobs
 
 * 🌐 **[Awesome Interview](https://github.com/DopplerHQ/awesome-interview-questions)** or [30-sec](https://30secondsofinterviews.org/) - Tech Interview Questions Indexes
-* 🌐 **[Summer 2024 Internships](https://github.com/SimplifyJobs/Summer2024-Internships)** - Tech Internships List / [Notifications](https://swelist.com/)
+* 🌐 **[Summer 2025 Internships](https://github.com/SimplifyJobs/Summer2024-Internships)** - Tech Internships List / [Notifications](https://swelist.com/)
 * 🌐 **[Free-Certifications](https://github.com/cloudcommunity/Free-Certifications)** - Free Certifications / Courses Index
 * 🌐 **[TheRemoteFreelancer](https://github.com/engineerapart/TheRemoteFreelancer)** - Remote Tech Jobs Index
 * ↪️ **[Learn Programming](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/edu/#wiki_.25BA_developer_learning)**


### PR DESCRIPTION
Looks like this linked repository is updated and they now handle Summer 2025 Internships as well, so I updated the year from 2024 to 2025. The old link redirects to the new link, so I updated the link as well just for the sake of consistency.