### PR TITLE
Update linuxguide.md

### DIFF
--- a/docs/linuxguide.md
+++ b/docs/linuxguide.md
@@ -43,7 +43,7 @@
 * ⭐ **[ArchWiki](https://wiki.archlinux.org/)** - Arch Linux Guide / [Manuals](https://man.archlinux.org/) / [TUI](https://codeberg.org/theooo/mantra.py)
 * [GameShell](https://github.com/phyver/GameShell) - Unix Shell Learning Game
 * [⁠InstallGentoo Wiki](https://igwiki.lyci.de/wiki/Main_Page) / [2](https://wiki.installgentoo.com/wiki/Main_Page) or [Gentoo Wiki](https://wiki.gentoo.org/wiki/Main_Page) - Gentoo Wikis / Guides
-* [⁠Debain Wiki](https://wiki.debian.org/) - ⁠Debain Wiki / Guides
+* [⁠Debian Wiki](https://wiki.debian.org/) - ⁠Debian Wiki / Guides
 * [LinuxJourney](https://linuxjourney.com/) - Interactive Linux Guides
 * [HowToLinux](https://howtolinux.vercel.app) - Linux Desktop Guides
 * [HowtoForge](https://www.howtoforge.com/) or [⁠Comfy.Guide](https://comfy.guide/) - Linux Server Software Guides


### PR DESCRIPTION
Linux Guides: Corrected spelling.

Under `Linux Guides`, 'The Debian Wiki' is listed as 'Debain Wiki', which is a typo. The description also has the wrong spelling. This is why I've fixed them by changing them both to `The Debian Wiki`.