### PR TITLE
Update aside alignment for posts and fixed TOC

### DIFF
--- a/docs/posts/Internet-Archive.md
+++ b/docs/posts/Internet-Archive.md
@@ -3,7 +3,7 @@ title: Internet Archive Breach
 description: Internet Archive was hacked
 date: 2024-10-09
 next: false
-aside: left
+aside: right
 prev: false
 
 footer: true

--- a/docs/posts/april-2023.md
+++ b/docs/posts/april-2023.md
@@ -3,7 +3,7 @@ title: Monthly Updates [April]
 description: April 2023 updates.
 date: 2023-04-01
 next: false
-aside: left
+aside: right
 prev: false
 
 footer: true

--- a/docs/posts/april-2024.md
+++ b/docs/posts/april-2024.md
@@ -3,7 +3,7 @@ title: Monthly Updates [April]
 description: April 2024 updates
 date: 2024-04-01
 next: false
-aside: left
+aside: right
 prev: false
 
 footer: true

--- a/docs/posts/aug-2023.md
+++ b/docs/posts/aug-2023.md
@@ -3,7 +3,7 @@ title: Monthly Updates [August]
 description: September 2023 updates.
 date: 2023-08-01
 next: false
-aside: left
+aside: right
 prev: false
 
 footer: true

--- a/docs/posts/aug-2024.md
+++ b/docs/posts/aug-2024.md
@@ -3,7 +3,7 @@ title: Monthly Updates [August]
 description: August 2024 updates
 date: 2024-08-01
 next: false
-aside: left
+aside: right
 prev: false
 
 footer: true

--- a/docs/posts/dec-2023.md
+++ b/docs/posts/dec-2023.md
@@ -3,7 +3,7 @@ title: Monthly Updates [December] 250k members!!
 description: Thank you all for 250K members! ♡
 date: 2023-12-01
 next: false
-aside: left
+aside: right
 prev: false
 
 footer: true

--- a/docs/posts/dec-2024.md
+++ b/docs/posts/dec-2024.md
@@ -3,7 +3,7 @@ title: Monthly Updates [December]
 description: December 2024 updates.
 date: 2024-12-01
 next: false
-aside: left
+aside: right
 prev: false
 
 footer: true
@@ -18,7 +18,7 @@ in seeing all minor changes you can follow our
 [Updates Channel](https://redd.it/17f8msf) in Discord.
 :::
 
-# Wiki Updates
+### Wiki Updates
 
 
 - Added [FFmpeg section](https://fmhy.net/video-tools#ffmpeg-tools) to Video Tools.
@@ -47,7 +47,7 @@ in seeing all minor changes you can follow our
 
 ***
 
-# Stars Added ⭐
+### Stars Added ⭐
 
 - Starred [Windows 10 After EOL](https://fmhy.net/system-tools#windows-updates) in Windows Updates. Continue to receive updates after Win10's End-Of-Life in Oct 2025.
 
@@ -70,8 +70,8 @@ in seeing all minor changes you can follow our
 - Starred [Citrus Search](https://fmhy.net/readingpiracyguide#academic-papers) in Academic Papers. Easily search and find similar papers for any topic.
 
 ***
- 
-# Things Removed
+
+### Things Removed
 
 - Removed free warp keys as they're being revoked now.
 

--- a/docs/posts/discord.md
+++ b/docs/posts/discord.md
@@ -3,7 +3,7 @@ title: Public Discord Server
 description: Our new space to chat in.
 date: 2023-10-24
 next: false
-aside: left
+aside: right
 prev: false
 
 footer: true

--- a/docs/posts/feb-2024.md
+++ b/docs/posts/feb-2024.md
@@ -3,7 +3,7 @@ title: Monthly Updates [Feb]
 description: Febuary 2024 updates.
 date: 2024-02-01
 next: false
-aside: left
+aside: right
 prev: false
 
 footer: true

--- a/docs/posts/feb-2025.md
+++ b/docs/posts/feb-2025.md
@@ -3,7 +3,7 @@ title: Monthly Updates [Feb]
 description: Febuary 2025 updates.
 date: 2025-02-01
 next: false
-aside: left
+aside: right
 prev: false
 
 footer: true
@@ -19,7 +19,7 @@ in seeing all minor changes you can follow our
 :::
 
 
-# Wiki Updates
+### Wiki Updates
 
 - Added [Concerts / Live Shows](https://fmhy.net/audiopiracyguide#concerts-live-shows) section to Audio.
 
@@ -35,7 +35,7 @@ in seeing all minor changes you can follow our
 
 ***
 
-# Stars Added ⭐
+### Stars Added ⭐
 
 - Starred [DeepSeek](https://fmhy.net/ai#online-chatbots) in Online Chatbots. V3 is unlimited and people seem to be really liking it so far.
 
@@ -62,8 +62,8 @@ in seeing all minor changes you can follow our
 - Added star back to [SteamGG](https://fmhy.net/gamingpiracyguide#download-games) in Game DDL. Game download site with pre-installs and good hosts, similar to SteamRIP. 
 
 ***
- 
-# Things Removed
+
+### Things Removed
 
 - Unstarred Firehawk52 as Deezer ARLs are being nuked instantly now.
 

--- a/docs/posts/filecr-malware.md
+++ b/docs/posts/filecr-malware.md
@@ -3,7 +3,7 @@ title: We Removed FileCR as we Found Malware
 description: Update on FileCR
 date: 2023-08-14
 next: false
-aside: left
+aside: right
 prev: false
 
 footer: true

--- a/docs/posts/jan-2024.md
+++ b/docs/posts/jan-2024.md
@@ -3,7 +3,7 @@ title: Monthly Updates [Jan] & Happy New Year!
 description: Happy New Year everyone! We've made a lot of progress this year.
 date: 2024-01-01
 next: false
-aside: left
+aside: right
 prev: false
 
 footer: true

--- a/docs/posts/jan-2025.md
+++ b/docs/posts/jan-2025.md
@@ -3,7 +3,7 @@ title: Monthly Updates [January]
 description: January 2025 updates.
 date: 2025-01-01
 next: false
-aside: left
+aside: right
 prev: false
 
 footer: true
@@ -19,7 +19,7 @@ in seeing all minor changes you can follow our
 :::
 
 
-# Wiki Updates
+### Wiki Updates
 
 * Created **[guides.fmhy.lol](https://guides.fmhy.lol/)** which lists all the guides we have throughout FMHY.
 
@@ -39,7 +39,7 @@ in seeing all minor changes you can follow our
 
 ---
 
-# Stars Added ⭐
+### Stars Added ⭐
 
 * Starred [Image FX](https://fmhy.net/ai#image-generation) in Image Gen + [Video FX](https://fmhy.net/ai#video-generation) in Video Gen. AI generators made by Google, US only.
 
@@ -60,8 +60,8 @@ in seeing all minor changes you can follow our
 * Starred [You Don't Need JavaScript](https://fmhy.net/devtools#css) in CSS Tools. Curated list of CSS demos.
 
 ---
- 
-# Things Removed
+
+### Things Removed
 
 * Removed Filehaus as they've [shut down](https://i.imgur.com/aNPHfAN.png)
 

--- a/docs/posts/july-2023.md
+++ b/docs/posts/july-2023.md
@@ -3,7 +3,7 @@ title: Monthly Updates [July]
 description: July 2023 updates.
 date: 2023-07-01
 next: false
-aside: left
+aside: right
 prev: false
 
 footer: true

--- a/docs/posts/july-2024.md
+++ b/docs/posts/july-2024.md
@@ -3,7 +3,7 @@ title: Monthly Updates [July]
 description: July 2024 updates.
 date: 2024-07-01
 next: false
-aside: left
+aside: right
 prev: false
 
 footer: true

--- a/docs/posts/jun-2023.md
+++ b/docs/posts/jun-2023.md
@@ -3,7 +3,7 @@ title: Monthly Updates [June]
 description: June 2023 updates.
 date: 2023-06-01
 next: false
-aside: left
+aside: right
 prev: false
 footer: true
 ---

--- a/docs/posts/june-2024.md
+++ b/docs/posts/june-2024.md
@@ -3,7 +3,7 @@ title: Monthly Updates [June]
 description: June 2024 updates
 date: 2024-06-01
 next: false
-aside: left
+aside: right
 prev: false
 
 footer: true

--- a/docs/posts/march-2024.md
+++ b/docs/posts/march-2024.md
@@ -3,7 +3,7 @@ title: Monthly Updates [March]
 description: March 2024 Updates
 date: 2024-03-01
 next: false
-aside: left
+aside: right
 prev: false
 
 footer: true

--- a/docs/posts/may-2023.md
+++ b/docs/posts/may-2023.md
@@ -3,7 +3,7 @@ title: Monthly Updates [May]
 description: May 2023 updates.
 date: 2023-05-01
 next: false
-aside: left
+aside: right
 prev: false
 
 footer: true

--- a/docs/posts/may-2024.md
+++ b/docs/posts/may-2024.md
@@ -3,7 +3,7 @@ title: Monthly Updates [May]
 description: May 2024 updates
 date: 2024-05-01
 next: false
-aside: left
+aside: right
 prev: false
 
 footer: true

--- a/docs/posts/new-site.md
+++ b/docs/posts/new-site.md
@@ -3,7 +3,7 @@ title: New Website
 description: Our brand new site (which you're on currently)
 date: 2023-11-12
 next: false
-aside: left
+aside: right
 prev: false
 
 footer: true

--- a/docs/posts/nov-2023.md
+++ b/docs/posts/nov-2023.md
@@ -3,7 +3,7 @@ title: Monthly Updates [November]
 description: October 2023 updates.
 date: 2023-11-01
 next: false
-aside: left
+aside: right
 prev: false
 
 footer: true

--- a/docs/posts/nov-2024.md
+++ b/docs/posts/nov-2024.md
@@ -3,7 +3,7 @@ title: Monthly Updates [November]
 description: Nov 2024 updates
 date: 2024-11-01
 next: false
-aside: left
+aside: right
 prev: false
 
 footer: true
@@ -18,7 +18,7 @@ in seeing all minor changes you can follow our
 [Updates Channel](https://redd.it/17f8msf) in Discord.
 :::
 
-# Wiki Updates
+### Wiki Updates
 
 - Added new FMHY backup domain: `FMHY.lol`
 
@@ -42,7 +42,7 @@ in seeing all minor changes you can follow our
 
 ***
 
-# Stars Added ⭐
+### Stars Added ⭐
 
 - Starred [Bluesky](https://fmhy.net/social-media-tools#fediverse-tools) in Fediverse Tools as everyone is leaving Twitter for it now.
 
@@ -69,8 +69,8 @@ in seeing all minor changes you can follow our
 - Went through [SMS verification](https://fmhy.net/storage#sms-verification-sites) and starred ones that stood out the most.
 
 ***
- 
-# Things Removed
+
+### Things Removed
 
 - Removed Mutaz as they no longer host cracked software.
 

--- a/docs/posts/oct-2023.md
+++ b/docs/posts/oct-2023.md
@@ -3,7 +3,7 @@ title: Monthly Updates [October]
 description: October 2023 updates.
 date: 2023-10-01
 next: false
-aside: left
+aside: right
 prev: false
 
 footer: true

--- a/docs/posts/oct-2024.md
+++ b/docs/posts/oct-2024.md
@@ -3,7 +3,7 @@ title: Monthly Updates [Oct 2024]
 description: October 2024 updates
 date: 2024-10-01
 next: false
-aside: left
+aside: right
 prev: false
 
 footer: true
@@ -18,7 +18,7 @@ in seeing all minor changes you can follow our
 [Updates Channel](https://redd.it/17f8msf) in Discord.
 :::
 
-# Wiki Updates
+### Wiki Updates
 
 - Did a complete overhaul of the **[Beginners Guide](https://fmhy.net/beginners-guide)**. Removed outdated links, added new sites, and rewrote all the tips.
 
@@ -30,7 +30,7 @@ in seeing all minor changes you can follow our
 
 ---
 
-# Stars Added ⭐
+### Stars Added ⭐
 
 - Starred [datadiff](https://fmhy.net/videopiracyguide#drives-directories) in Drives / Directories. Media directory with fast download speed, similar to vadapav / moo.
 
@@ -57,8 +57,8 @@ in seeing all minor changes you can follow our
 - Starred [Simple Tab Groups](https://fmhy.net/storage#tab-managers) in Tab Managers. Feature-rich tab manager with plugin support.
 
 ---
- 
-# Things Removed
+
+### Things Removed
 
 - Removed Essential from minecraft mods as they have a history of malicious practices and there are better options anyways.
 

--- a/docs/posts/search.md
+++ b/docs/posts/search.md
@@ -3,7 +3,7 @@ title: How-to Search FMHY
 description: Various tools to help you query FMHY.
 date: 2023-01-07
 next: false
-aside: left
+aside: right
 prev: false
 
 footer: true

--- a/docs/posts/sept-2023.md
+++ b/docs/posts/sept-2023.md
@@ -3,7 +3,7 @@ title: Monthly Updates [September]
 description: September 2023 updates.
 date: 2023-09-01
 next: false
-aside: left
+aside: right
 prev: false
 
 footer: true

--- a/docs/posts/sept-2024.md
+++ b/docs/posts/sept-2024.md
@@ -3,7 +3,7 @@ title: Monthly Updates [Sept]
 description: September 2024 updates
 date: 2024-09-01
 next: false
-aside: left
+aside: right
 prev: false
 
 footer: true


### PR DESCRIPTION
This should fix the aside alignment for the Posts, also changed some headings because by default VitePress ignores single # and only takes from H2 - H6 which is why it doesn't get displayed in the table of content

In the main page, it works, because the transformer code changes from # > to ##, but the changes only apply to pages that are not posts