### PR TITLE
add SpotifyAB to Spotify Adblockers section

### DIFF
--- a/docs/audiopiracyguide.md
+++ b/docs/audiopiracyguide.md
@@ -237,6 +237,7 @@
 
 * ⭐ **[SpotX](https://github.com/SpotX-Official/SpotX)** / [Telegram](https://t.me/SpotxCommunity)
 * ⭐ **[BlockTheSpot](https://github.com/mrpond/BlockTheSpot)** / [Discord](https://discord.gg/9tCNMFESuC)
+* ⭐ **[SpotifyAB](https://github.com/An0n-00/SpotifyAB)**
 * [BurntSushi](https://github.com/OpenByteDev/burnt-sushi)
 * [Spotify Adblock Guide](https://redd.it/yme7pf)
 * Spotify Mobile Adblock - [Android](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/android/#wiki_.25BA_android_audio) / [iOS](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/android/#wiki_.25BA_ios_audio)


### PR DESCRIPTION
This pull request includes a small change to the `docs/audiopiracyguide.md` file. The change adds a new entry for `SpotifyAB` to the list of Spotify ad-blocking tools.

* [`docs/audiopiracyguide.md`](diffhunk://#diff-84c97950a1b3b1a4e3d25da603bd811c82cafe3ec9b1107107b8f1b57c43cc10R240): Added `SpotifyAB` to the list of Spotify ad-blocking tools.

Spotify AdBlocker (SpotifyAB) is designed to block ads and trackers directly within the Spotify desktop app for Windows. The project utilizes JavaScript injection into the Spotify application to block ads and trackers. 