### PR TITLE
remove paper-io.com and hole-io.com

### DIFF
--- a/docs/gamingpiracyguide.md
+++ b/docs/gamingpiracyguide.md
@@ -384,9 +384,8 @@
 * [Minecraft Classic](https://classic.minecraft.net/) - Browser Minecraft
 * [Moo Moo](https://moomoo.io/) - Multiplayer Survival Game
 * [Slither.io](http://slither.io/) - Grow the Longest Worm
-* [Hexar.io](http://www.hexar.io/), [splix.io](https://splix.io/) or [paper-io](https://paper-io.com/) - Control the Map 
+* [Hexar.io](http://www.hexar.io/), [splix.io](https://splix.io/) or - Control the Map 
 * [agar.io](https://agar.io/) - Become the Biggest Circle
-* [Hole.io](https://hole-io.com/) - Become the Biggest Hole / [Discord](https://discord.gg/UA2HdpT) 
 * [Deeeep](https://deeeep.io/) - Multiplayer Feeding Frenzy Games
 * [SpaceCadetPinball](https://alula.github.io/SpaceCadetPinball) - Browser Space Cadet Pinball
 * [The Circle](https://the-circle.app/) - Dodge Circles


### PR DESCRIPTION
paper-io.com is now no longer a browser game and only exists on mobile devices
![image](https://github.com/user-attachments/assets/d8b424cc-e6d2-45e9-b0b7-4359ab419c58)
ios:https://apps.apple.com/us/app/paper-io-2/id1423046460?mt=8
android:https://apps.apple.com/us/app/paper-io-2/id1423046460?mt=8


and hole-io.com is the same but just redirecs to https://voodoo.io/ instead 
its on 
ios :https://apps.apple.com/us/app/hole-io/id1389111413
android:https://play.google.com/store/apps/details?id=io.voodoo.holeio&hl=en_CA
steam:https://store.steampowered.com/app/2751230/Hole_io/ (it's paid)

voodoo has a bunch of annyoing ads for all there games though so it shouldn't be added back elsewhere