### PR TITLE
Move the site sagen.at from the Russian to the German Reading section.

### DIFF
--- a/docs/non-english.md
+++ b/docs/non-english.md
@@ -565,6 +565,7 @@
 * [MyComics](https://www.mycomics.de/) - Comics
 * [Kanjiku](https://kanjiku.net/) - Manga
 * [Hoerbuch](https://hoerbuch.us/) - Audiobooks
+* [Sagen](https://www.sagen.at/) - European Ethnology / Folklore
 
 ***
 
@@ -1475,7 +1476,6 @@ Italian
 * [Samlib](http://samlib.ru/) - Document Search
 * [militera](http://militera.org/) - Military History
 * [Arzamas](https://arzamas.academy/) - Cultural History
-* [Sagen](https://www.sagen.at/) - European Ethnology / Folklore
 * [Playing Soviet](https://commons.princeton.edu/soviet/) - Children's Books
 * [Baza Knig](https://baza-knig.ink/), [Flibusta_Anglysky](https://t.me/flibusta_anglysky), [Аkniga](https://akniga.org/), [Bibl](https://m.biblus.in/), [Knizhkin](https://knizhkin.net/) or [Bibl.us](https://bibl.us/) - Audiobooks
 * [Science Lab](https://fantlab.ru/) - Sci-Fi Book Discussion


### PR DESCRIPTION
This site is placed in the wrong section on the site. It is currently located in the "Russian" section, while being focused on Austrian folklore.

It also does not contain an article in the Russian language.