### PR TITLE
Add ArtistAssistApp to img-tools.md

### DIFF
--- a/docs/img-tools.md
+++ b/docs/img-tools.md
@@ -832,6 +832,7 @@
 * [Color Lisa](https://colorlisa.com/) - Find Art-Based Color Palettes
 * [Color Leap](https://colorleap.app/) - Find Historical Color Palettes
 * [COLORWISE](https://colorwise.io/) - Find Color Palettes from Product Hunt Products
+* [ArtistAssistApp](https://artistassistapp.com/) - Accurately Match and Mix Any Color From an Image With Real Paints
 
 ***
 


### PR DESCRIPTION
Add https://artistassistapp.com/

## Description

[ArtistAssistApp](https://artistassistapp.com/) is painting and drawing assistant web app helping artists accurately match and mix any color from an image with real paints they have on hand. All app features are available for free without login or registration. There is also a paid version with a larger number of color brands.

## Context

## Types of changes

* [ ] Bad / Deleted sites removal
* [ ] Grammar / Markdown fixes
* [X] Content addition (sites, projects, tools, etc.)
* [ ] New Wiki section

## Checklist

* [X] I have read the [contribution guide](https://fmhy.net/other/contributing).
* [X] I have made sure to [search](https://api.fmhy.net/single-page) before making any changes.
* [X] My code follows the code style of this project.
