### PR TITLE
Update miscguide.md - add Nomadlio.com

### DIFF
--- a/docs/miscguide.md
+++ b/docs/miscguide.md
@@ -781,7 +781,7 @@
 * [/r/RemoteJobs](https://www.reddit.com/r/RemoteJobs/) - Remote Jobs Subreddit (Check "Job Posts" flag)
 * [MTurk](https://www.mturk.com/) - Online Task Work
 * [NoCommute](https://www.nocommutejob.com/) - Remote Job Notifications
-* [WeNomad](https://wenomad.so/) or [Nomad List](https://nomads.com/) - Remote Work Ratings
+* [Nomadlio](https://nomadlio.com/), [WeNomad](https://wenomad.so/) or [Nomad List](https://nomads.com/) - Remote Work Ratings
 * [Jobspresso](https://jobspresso.co/) - Remote Jobs
 * [Remote Jobs](https://remotejobs.com/) - Remote Jobs
 * [himalayas](https://himalayas.app/) - Remote Jobs


### PR DESCRIPTION
Hello I'm Yair the founder of Nomadlio, would love to add it to the wiki.

It's an alternative to Nomads.com (previously Nomadlist), I recommend adding it because it has a few big advantages to Nomads.com:
- It is 100% free, unlike Nomads.com which is paywalled after starting to use the website
- We're fully transparent about where the data is from in the website and FAQ
- It has ~5600 destinations, 4x more than Nomads.com