### PR TITLE
Adding Wipr2 to iOS adblocking

### DIFF
--- a/docs/android-iosguide.md
+++ b/docs/android-iosguide.md
@@ -1106,6 +1106,7 @@
 * [Brave](https://apps.apple.com/app/id1052879175) - Adblock Browser
 * [1Blocker](https://1blocker.com/) - Adblocker
 * [Stay](https://apps.apple.com/app/stay-for-safari/id1591620171) - Safari Adblocker / Userscript Manager
+* [Wipr 2](https://kaylees.site/wipr2.html) - Simple and lightweight Safari Adblocker
 * [iSponsorBlock](https://github.com/Galactic-Dev/iSponsorBlock) - Skip YouTube Sponsorships
 * [SponsorBlock for YT Music](https://github.com/dayanch96/SponsorBlock-YouTubeMusic) - Skip Non-Music Segments in YouTube Music
 * [TwitterNoAds](https://github.com/Netskao/TwitterNoAds) - iOS X.com AdBlock / Download DEB then add to decrypted IPA


### PR DESCRIPTION
Wipr 2 is a simple (no configuration, just enable it and forget it) and lightweight (it doesn't slow down Safari) adblocker, i think its worth recommending it