### PR TITLE
Update miscguide.md, Deleted BoozeTube

### DIFF
--- a/docs/miscguide.md
+++ b/docs/miscguide.md
@@ -175,7 +175,6 @@
 * [Nahbucks!](https://nahbucks.com/) - Find Local Non-Starbucks Coffee Shops (US)
 * [Drinkable](https://github.com/MOIMOB/drinkable) - Create Cocktails from Home Ingredients
 * [Drinknation](https://www.drinknation.com/bar) or [Make Me a Cocktail](https://makemeacocktail.com/mybar/) - Cocktail Builders
-* [BoozeTube](https://boozetube.netlify.app/) - Turn Videos into Drinking Games
 
 ***
 


### PR DESCRIPTION
BoozeTube is depracated.
The code is old and its not support by wasp anymore plus the website gives fetching errors.