### PR TITLE
Update adblockvpnguide.md

### DIFF
--- a/docs/adblockvpnguide.md
+++ b/docs/adblockvpnguide.md
@@ -281,7 +281,6 @@
 
 * ⭐ **[CanvasBlocker](https://github.com/kkapsner/CanvasBlocker)** - Prevent Canvas Fingerprinting
 * ⭐ **[CreepJS](https://abrahamjuliot.github.io/creepjs)**, [webkay](https://webkay.robinlinus.com/), [browserrecon](https://www.computec.ch/projekte/browserrecon/?s=scan), [TZP](https://arkenfox.github.io/TZP/tzp.html), [Device Info](https://www.deviceinfo.me/), [Cover Your Tracks](https://coveryourtracks.eff.org/) or [PersonalData](https://personaldata.info/) - Tracking / Fingerprinting Tests
-* [ClearURLs](https://docs.clearurls.xyz) - Remove Tracking Elements from URLs / Can Break Sites / [GitHub](https://github.com/ClearURLs/Addon) / [GitLab](https://gitlab.com/KevinRoebert/ClearUrls)
 * [Webbkoll](https://webbkoll.5july.net/) or [Blacklight](https://themarkup.org/blacklight) - Site Tracking Info
 * [Data Removal Guide](https://inteltechniques.com/workbook.html) - Remove Online Data
 * [GameIndustry](https://gameindustry.eu/en/) - Block Trackers in Desktop / Mobile Games


### PR DESCRIPTION
Redundant with uBlock Origin's [removeparam](https://github.com/gorhill/uBlock/wiki/Static-filter-syntax#removeparam) and added lists. Any potential extra coverage provided by additional extensions is going to be minimal
https://github.com/arkenfox/user.js/wiki/4.1-Extensions#-dont-bother