### PR TITLE
Remove CRACKSurl from Software Sites

### DIFF
--- a/docs/downloadpiracyguide.md
+++ b/docs/downloadpiracyguide.md
@@ -123,7 +123,6 @@
 
 * 🌐 **[Adobe Alternatives](https://github.com/KenneyNL/Adobe-Alternatives)**, [2](https://rentry.org/adobealt) - Adobe Software Alternative Index
 * ↪️ **[Windows ISOs / Activation](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/system-tools#wiki_.25BA_windows_isos)**
-* ⭐ **[CRACKSurl](https://cracksurl.com/)** / [Telegram](https://t.me/cracksurldotcom)
 * ⭐ **[LRepacks](https://lrepacks.net/)**
 * ⭐ **[Mobilism](https://forum.mobilism.org/)** - [Mobile App](https://forum.mobilism.org/app/)
 * ⭐ **[soft98](https://soft98.ir/)** - Use [Translator](https://addons.mozilla.org/en-US/firefox/addon/traduzir-paginas-web/) / [Anti-Adblock Fix](https://github.com/AdguardTeam/AdGuardExtra)


### PR DESCRIPTION
**ESET** blocks the site: "_This web page may contain dangerous content that can provide remote access to an infected device, leak sensitive data from the device or harm the targeted device._"

**Virustotal**: _7/97 security vendors flagged this URL as malicious_
https://www.virustotal.com/gui/url/4f80df32ca1d0cc4d40f33fa70134743e76ec9ba58762576b601c656db6d9e5b