### PR TITLE
Add Stremio tool link for Stremlist in videopiracyguide.md

### DIFF
--- a/docs/videopiracyguide.md
+++ b/docs/videopiracyguide.md
@@ -774,6 +774,7 @@
 * [Anime Catalogs](https://1fe84bc728af-stremio-anime-catalogs.baby-beamup.club/configure) - Stremio Anime Catalogs
 * [Simkl Stremio](https://simkl.com/apps/stremio/) - Simkl for Stremio
 * [Trakt Stremio](https://2ecbbd610840-trakt.baby-beamup.club/) - Trakt for Stremio
+* [Stremlist](https://stremlist.com/) - IMDb Watchlist in Stremio
 
 ***
 


### PR DESCRIPTION
Hey, 
This is the addon I created for syncing your IMDb watchlist and have it as a catalog in Stremio.

It has nearly 1500 users as of today,
[stremlist.com](https://stremlist.com)
I don't save any information about the user, the only information I need is the URL of his IMDb profile.

I [shared it in r/StremioAddons](https://www.reddit.com/r/StremioAddons/comments/1ji7vch/i_created_stremlist_a_free_stremio_addon_that/) and many users were waiting for an addon like this.

I add new features whenever I can and actively listen to user feedback for fixes :)