### PR TITLE
Added pdfdrive.cloud under PDF Search section

### DIFF
--- a/docs/readingpiracyguide.md
+++ b/docs/readingpiracyguide.md
@@ -78,6 +78,7 @@
 * ⭐ **[PDF Drive](https://www.pdfdrive.com/)** - Books
 * [8kun Library](https://8kun.top/pdfs/index.html) - Books
 * [Ocean of PDF](https://oceanofpdf.com/) - Books / Comics
+* [PDF Drive Cloud](https://pdfdrive.cloud/) - Books
 * [pdfroom](https://pdfroom.com/) - Books / Comics
 * [Ebook PDF](https://ebookpdf.com/) - Books
 * [KuPDF](https://kupdf.net/) - Books


### PR DESCRIPTION
The site offers a large searchable library of downloadable PDFs (books, academic material, etc.) with no sign-up required.
I’ve checked and it wasn’t listed already. It fits under the category of direct-access reading resources.