### PR TITLE
Add 2 stations to *Internet Radios*

### DIFF
--- a/docs/audiopiracyguide.md
+++ b/docs/audiopiracyguide.md
@@ -204,6 +204,8 @@
 * [Campus FM](https://www.campus-fm.com/) - College Radio
 * [RadioSide](https://radioside.com/) - Internet Radio Receiver
 * [streamWriter](https://streamwriter.org/en/) - Internet Radio Audio Downloader
+* [Radio Dyne.org](https://radio.dyne.org/) - Hacker collective radio directory
+* [Basspistol Radio](https://radio.basspistol.com) - Ringing freedom since 2010
 
 ***
 


### PR DESCRIPTION
Dyne is a hacker collective founded in the late 90s. Their Radio directory has been online for as long as i can remember. 

Basspistol Radio is streaming creative commons licensed and independent music provided to the station consensually by their respective authors, 365/24/7 since 2010. It facilitates easy support of the artists.