### PR TITLE
Add Hyperurls.com

### DIFF
--- a/docs/internet-tools.md
+++ b/docs/internet-tools.md
@@ -546,6 +546,7 @@
 ## ▷ Bookmark Managers
 
 * ⭐ **[Raindrop.io](https://raindrop.io/)** - Cross-Platform Manager
+* [HyperURLs.com](https://hyperurls.com?ref=edit) - Web-Based Manager & Chrome Extension
 * [Start.me](https://about.start.me/) - Web-Based Manager
 * [Bort](https://bort.io/) - Web-Based Manager / Requires Dropbox
 * [wallabag](https://wallabag.org/) - Web-Based Manager


### PR DESCRIPTION
Added Hyperurls.com under the Bookmarking section. I provid Web + Telegram + Extension as source, hence added to the list. Thanks!