### PR TITLE
Remove obsolete tool from "VSCode Tools" section

### DIFF
--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -610,7 +610,6 @@
 ## ▷ VSCode Tools
 
 * 🌐 **[Awesome VSC Extensions](https://hl2guide.github.io/Awesome-Visual-Studio-Code-Extensions/)**, [2](https://marketplace.visualstudio.com/) - VSCode Extensions
-* [github-vscode-icons](https://github.com/dderevjanik/github-vscode-icons) - VSCode Icons
 * [chatgpt-vscode](https://github.com/mpociot/chatgpt-vscode) - VSCode ChatGPT
 * [Open VSX](https://open-vsx.org/) - Open VSX Registry
 * [snippet-generator](https://snippet-generator.app/) - Snippet Generator


### PR DESCRIPTION
Removes [github-vscode-icons](https://github.com/dderevjanik/github-vscode-icons), a browser extension that adds vscode icons to github.com.
It has not been maintained for 4 years. Currently, there is an alternative, [material-icons-browser-extension](https://github.com/material-extensions/material-icons-browser-extension) which is already added to FMHY!