### PR TITLE
Add: Add new tool "YouTube Thumbnail Grabber" to social-media-tools.md

### DIFF
--- a/docs/social-media-tools.md
+++ b/docs/social-media-tools.md
@@ -338,7 +338,7 @@
 * [LiveTL](https://kentonishi.com/LiveTL/) - Livestream Chat Translator
 * [YT Boost Chat](https://greasyfork.org/en/scripts/520755) or [YT RM3](https://greasyfork.org/en/scripts/521342) - Reduce YouTube Chat Memory Usage
 * [YT LiveChat Flusher](https://github.com/ys-j/YoutubeLiveChatFlusher) - Add Bullet Chatting (Danmaku) to Livestreams
-
+* [YouTube Thumbnail Grabber](https://youtube-thumbnail-grabber.org/) - Instantly Download YouTube Video Thumbnails
 ***
 
 ## ▷ YouTube Customization


### PR DESCRIPTION
Added a new tool entry for [YouTube Thumbnail Grabber](https://youtube-thumbnail-grabber.org/) to the existing list of YouTube Tools.

I have already checked to ensure it's not already in the wiki.

This tool allows users to instantly download YouTube video thumbnails in high quality, which can be useful for content creators, archivists, or anyone working with YouTube metadata.

The format and description were kept consistent with the existing style of the list.