### PR TITLE
Add SubHarbor to Reddit Alternatives section

### DIFF
--- a/docs/social-media-tools.md
+++ b/docs/social-media-tools.md
@@ -211,6 +211,7 @@
 * [Scored](https://communities.win/) - User-Driven Discussion
 * [Ramble](https://ramble.pw/) - Privacy-Focused
 * [Discuit](https://discuit.org/) - Centralized Reddit Alt with User Control
+* [SubHarbor](https://subharbor.com/) - Subreddit fallback & alternative links
 
 ***
 


### PR DESCRIPTION
This PR adds [SubHarbor (subharbor.com)](https://subharbor.com) to the "Reddit Alternatives" section. SubHarbor is a platform designed as a decentralized backup and discovery hub for subreddit communities. It aims to help users stay connected and informed in case of Reddit outages, shutdowns, or censorship.

Key features of SubHarbor include:

* Public directory of alternative subreddit community spaces
* Minimalist, no-login-needed design
* Community-driven entries with mod verification badges (optional)
* Focused on transparency and decentralization

Adding SubHarbor provides those browsing the _Reddit Alternatives_ section a platform to facilitate the move to a new location, an invaluable resource for community continuity and backup planning. 