### PR TITLE
Added akwebguide to Android / iOS section

### DIFF
--- a/docs/android-iosguide.md
+++ b/docs/android-iosguide.md
@@ -1172,6 +1172,7 @@
 * [Decrypted App Store](https://armconverter.com/decryptedappstore), [AnyIPA](https://anyipa.me/) / [Telegram](https://t.me/AnyIPAme) / [Discord](https://discord.gg/c233DYUzsw) or [decrypt.day](https://decrypt.day/) - Decrypted iOS Apps
 * [AppSnake](https://appsnake.cypwn.xyz/) - Check if Unlockers Work on App
 * [Calvink19](https://calvink19.co/patch) - App Patches for iOS Legacy Devices
+* [akwebguide](https://www.akwebguide.com) - Unlocked Apple ID service for a variety of paid applications
 
 ***
 


### PR DESCRIPTION
This pull request adds a new resource to the `docs/android-iosguide.md` file. The change introduces a link to `akwebguide`, which provides an unlocked Apple ID service for accessing a variety of paid applications.