### PR TITLE
Add new tool "LandOfReaders" to readingpiracyguide.md

### DIFF
--- a/docs/readingpiracyguide.md
+++ b/docs/readingpiracyguide.md
@@ -903,6 +903,7 @@
 * [Shepherd](https://shepherd.com/) - Book Recommendations
 * [Newvella](https://newvella.com/) - Book Discovery / Recommendations
 * [GoodBooks](https://www.goodbooks.io/) - Book Discovery / Reviews
+* [LandOfReaders](https://www.landofreaders.com/) - Book Recommendations
 * [Literature-Map](https://www.literature-map.com/) - Author Discovery by Genre
 * [Break the Bubble!](https://abooklike.foo/escape) - Challenge Narrow Tastes
 * [Most Recommended Books](https://www.mostrecommendedbooks.com/) - Book Recommendations


### PR DESCRIPTION
Added [LandOfReaders](https://www.landofreaders.com/) to readingpiracyguide.md under Curated Recommendations.

It is a free tool.

The tool is not listed anywhere in the Wiki. I made sure that formatting is consistent.

---

Land Of Readers description:

"Answer 6 quick questions and get a personalized book recommendation tailored to your mood, interests, and reading goals. Say goodbye to decision fatigue — your next great read is just a few clicks away. "