### PR TITLE
fix: loosen-up Feedback schema

### DIFF
--- a/docs/.vitepress/types/Feedback.ts
+++ b/docs/.vitepress/types/Feedback.ts
@@ -19,9 +19,9 @@ import z from 'zod'
 export const FeedbackSchema = z.object({
   message: z.string().min(5).max(1000),
   type: z.enum(['suggestion', 'appreciation', 'other']),
-  page: z.string().min(3).max(20),
+  page: z.string().min(3).max(25),
   // For heading based feedback
-  heading: z.string().min(3).max(20).optional()
+  heading: z.string().min(3).max(99).optional()
 })
 
 export interface Option {


### PR DESCRIPTION
The current feedback schema is too tight.

Trying to submit feedback in the "Digital Art Collections" heading - or in other longer headings fails, due to the schema limiting the heading field to 20 characters, which is shorter than some of the existing headings.

I liberally loosened-up the API request schema to allow for longer headings & page titles to be correctly interacted with and allow enough buffer in length so that the issue hopefully doesn't arise again.

## Current State
Example Request (by using the feedback button next to the heading):
<img width="268" height="124" alt="image" src="https://github.com/user-attachments/assets/88c593ec-6a64-447e-84e9-132133f1167a" />
Error Response:
<img width="431" height="212" alt="image" src="https://github.com/user-attachments/assets/c200fd6a-f7c8-430f-8388-f595475cad36" />
