### PR TITLE
Update non-english.md

### DIFF
--- a/docs/non-english.md
+++ b/docs/non-english.md
@@ -833,7 +833,7 @@
 
 ## ▷ Streaming
 
-* [StreamingCommunity](https://streaming-community.bio/) - Movies / TV
+* [StreamingCommunity](https://streamingcommunityz.info/) - Movies / TV
 * [Altadefinizione](https://altadefinizionegratis.life/) - Movies / Sub / Dub / 1080p / 4K
 * [CasaCinema](https://casacinema.world/) - Movies / TV / Anime / Sub / Dub / 1080p / 4K
 * [RaiPlay](https://www.raiplay.it/) - Movies / TV / Dub


### PR DESCRIPTION
The official StreamingCommunity domain name is always available [here](https://telegra.ph/Link-Aggiornato-StreamingCommunity-09-29), sometimes it changes, FMHY always had the official one, even when it changed, but when I noted that it now had a fake domain I decided to contribute.