### PR TITLE
Update search.md

### DIFF
--- a/docs/posts/search.md
+++ b/docs/posts/search.md
@@ -63,7 +63,7 @@ Multi-site search engines
 
 FMHY Dupe Check Tool
 
---
+---
 
 ### Search Page Backups
 


### PR DESCRIPTION
Fixed error where there were only 2 dashes above the Search Page Backups section, making the two dashes show and not look like a horizontal rule.