### PR TITLE
Refactor: Hackintosh and LaTeX Tools Cleanup

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -179,27 +179,6 @@
 
 ***
 
-## Hackintosh
-
-* ⭐ **[Hackintosh](https://hackintosh.com/)** - Hackintosh Building Guides
-* ⭐ **[Dortania](https://dortania.github.io/OpenCore-Install-Guide/)** - Hackintosh Building Guides
-* ⭐ **[/r/Hackintosh](https://www.reddit.com/r/hackintosh/)** - Hackintosh Community / Subreddit / [Discord](https://discord.gg/u8V7N5C)
-* [/r/Hackintosh Tools](https://www.reddit.com/r/hackintosh/comments/npvuqg/hackintosh_macos_free_tools/) or [hackintosh-tools](https://rentry.org/hackintosh-tools) - Hackintosh Tools
-* [OneClick-macOS](https://github.com/notAperson535/OneClick-macOS-Simple-KVM) - macOS Virtual Machines using QEMU
-* [OSX-PROXMOX](https://rentry.co/FMHYBase64#osx-proxmox) - macOS on Proxmox
-* [OpenCore-Legacy-Patcher](https://dortania.github.io/OpenCore-Legacy-Patcher) - Hackintosh for Unsupported Hardware / [GitHub](https://github.com/dortania/OpenCore-Legacy-Patcher)
-* [VMware Workstation Hackintosh](https://docs.bluebubbles.app/server/advanced/macos-virtualization/running-a-macos-vm/deploying-macos-in-vmware-on-windows-full-guide) - Install macOS in Vmware Workstation
-* [Ryzen-hackintosh](https://github.com/mikigal/ryzen-hackintosh) - Hackintosh for Ryzen
-* [Xiaomi-Pro-Hackintosh](https://github.com/daliansky/XiaoMi-Pro-Hackintosh) - Hackintosh for Xiaomi
-* [Unplugged](https://github.com/corpnewt/UnPlugged) - Bash Script for macOS Offline Installer
-* [EFI-Agent](https://github.com/benbaker76/EFI-Agent) - GUI App to Mount EFI Partitions
-* [Vmware Tools](https://packages.vmware.com/tools/frozen/darwin/) - VMware Tools ISO for macOS VM / [Unlocker](https://rentry.co/FMHYBase64#vmware-workstation)
-* [Emaculation](https://www.emaculation.com/) or [felixrieseberg](https://github.com/felixrieseberg/macintosh.js/) - Virtual macOS
-* [macOS for all computers](https://github.com/yusufklncc/Hackintosh-for-All-Computers) - Contains Prebuilt EFI for Systems
-* [Tonymacx86](https://www.tonymacx86.com/) or [Olarilla](https://olarila.com/) - Customized macOS for Intel and AMD / [Notes](https://rentry.org/what-to-choose)
-
-***
-
 ## Internet Archive Tools
 
 - [Archive.org-Downloader](https://github.com/MiniGlome/Archive.org-Downloader) - Download Books in PDF Format
@@ -231,21 +210,6 @@
 * [KanjiTomo](https://kanjitomo.net/) - Kanji Character Identifier
 
 [WaniKani](https://www.wanikani.com/), [KanjiDamage](https://www.kanjidamage.com/) / [KanjiDamagePlus](https://kanjidamageplus.neocities.org/), [Kanji-Dojo](https://github.com/syt0r/Kanji-Dojo), [Koohii](https://kanji.koohii.com/) / [Deck](https://ankiweb.net/shared/info/748570187), [Manji](https://github.com/Livinglist/Manji)
-
-***
-
-## LaTeX Tools
-
-* [Learn LaTeX](https://www.learnlatex.org/) - LaTeX Guide
-* [Gilles Castel](https://castel.dev/) - Homework & Note Writing Guides
-* [Overleaf](https://www.overleaf.com/), [TeXStudio](https://texstudio.org/) or [Papeeria](https://papeeria.com/) - LaTeX Editors
-* [Typst](https://typst.app/home) / [GitHub](https://github.com/typst/typst) or [R Markdown](https://rmarkdown.rstudio.com/) - LaTeX Alternatives
-* [Tables Generator](https://www.tablesgenerator.com/) - Create LaTeX Tables
-* [Quick LaTeX](https://quicklatex.com/) - Generate LaTeX Images
-* [Tips for Writing a Research Paper using LaTeX](https://github.com/guanyingc/latex_paper_writing_tips)
-* [SimpleTex](https://simpletex.net/) - Formula Recognition to MathML and LaTeX / [Online](https://simpletex.net/ai/latex_ocr)
-* [Math Scan](https://github.com/ekrem-qb/math_scan), [RapidLatexOCR](https://github.com/RapidAI/RapidLatexOCR) or [LaTeX-OCR](https://lukas-blecher.github.io/LaTeX-OCR/) - Extract Mathematical Expressions
-* [Detexify](https://detexify.kirelabs.org/classify.html) - Character Recognition
 
 ***
 

--- a/docs/system-tools.md
+++ b/docs/system-tools.md
@@ -173,7 +173,6 @@
 
 * 🌐 **[Awesome Web Desktops](https://github.com/syxanash/awesome-web-desktops)** or [Simone's Computer](https://simone.computer/#/webdesktops) - OS Emulators / VMs
 * ↪️ **[Android Emulators](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/android#wiki_.25BA_android_emulators)**
-* ↪️ **[Hackintosh Resources](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/storage#wiki_hackintosh)**
 * ⭐ **[VMware Workstation](https://www.majorgeeks.com/files/details/vmware_workstation_for_windows.html)** or **[VirtualBox](https://www.virtualbox.org/)** / [Portable](https://www.vbox.me/) - Virtual Machines
 * ⭐ **[Virt-Manager](https://virt-manager.org/)** / [GitHub](https://github.com/virt-manager/virt-manager), [MultiPass](https://canonical.com/multipass) / [GitHub](https://github.com/canonical/multipass) or [Vagrantup](https://www.vagrantup.com/) / [GitHub](https://github.com/hashicorp/vagrant) - Virtual Machine Managers
 * [Looking Glass](https://looking-glass.io/) - App for Using Kernel-Based Virtual Machine Configured for VGA PCI Pass-Through / [GitHub](https://github.com/gnif/LookingGlass)
@@ -189,6 +188,21 @@
 * [Blink](https://github.com/jart/blink) - Linux Emulator for Windows
 * [Dockerholics](https://github.com/petersem/dockerholics) - Docker Apps
 * [WebCatalog](https://webcatalog.io) - Turn Sites into Desktop Apps
+
+***
+
+## ▷ Hackintosh
+
+* **Note** - Generating a unique SMBIOS is crucial for Apple services like iMessage and iCloud to function properly.
+
+***
+
+* ⭐ **[Hackintosh](https://hackintosh.com/) / [Subreddit](https://www.reddit.com/r/hackintosh/) / [Discord](https://discord.gg/u8V7N5C)** - Hackintosh Building Guides
+* ⭐ **[Dortania](https://dortania.github.io/OpenCore-Install-Guide/)** - Hackintosh Installation Guide
+* [OpenCore-Legacy-Patcher](https://dortania.github.io/OpenCore-Legacy-Patcher) - macOS on Unsupported Hardware
+* [OneClick-macOS](https://github.com/notAperson535/OneClick-macOS-Simple-KVM) - macOS VM with QEMU
+* [Emaculation](https://www.emaculation.com/) - Virtual macOS Environments
+* [Hackintosh Tools](https://rentry.org/hackintosh-tools)
 
 ***
 

--- a/docs/text-tools.md
+++ b/docs/text-tools.md
@@ -186,6 +186,17 @@
 
 ***
 
+## ▷ LaTeX Tools
+
+* ⭐ **[Overleaf](https://www.overleaf.com/) or [TeXStudio](https://texstudio.org/)** - LaTeX Editors
+* [Learn LaTeX](https://www.learnlatex.org/) - LaTeX Guide
+* [Typst](https://typst.app/home) / [GitHub](https://github.com/typst/typst) - LaTeX Alternative
+* [Tables Generator](https://www.tablesgenerator.com/) - Create LaTeX Tables
+* [LaTeX-OCR](https://lukas-blecher.github.io/LaTeX-OCR/) - Extract Mathematical Expressions
+* [Detexify](https://detexify.kirelabs.org/classify.html) - Character Recognition
+
+***
+
 # ► Text Editors
 
 * 🌐 **[List of Text Editors](https://en.wikipedia.org/wiki/List_of_text_editors)** - Text Editor / Notepad Index


### PR DESCRIPTION
### Hackintosh

**Category Change:**

*   Moved `Hackintosh` from *Storage* to *System Tools*.

**Site Removals:**

*   Removed `OSX-PROXMOX` & `VMware Workstation Hackintosh`.
    *   **Reason:** too niche. these are guides for specific virtualization platforms. the more general `Virtual macOS` link is a better catch-all resource for users interested in virtualization.
*   Removed `Ryzen-hackintosh` & `Xiaomi-Pro-Hackintosh`.
    *   **Reason:** too niche. Dortania's main guide has dedicated sections for AMD CPUs and various laptop models.
*   Removed `Unplugged`, `EFI-Agent`, `VMware Tools/Unlocker`.
    *   **Reason:** these are specific tools that are either covered in the main Dortania guide or included in the more comprehensive `Hackintosh Tools Rentry` link. reduces redundancy.
*   Removed `felixrieeberg/macintosh.js`.
    *   **Reason:** redundant. Emaculation is a more comprehensive resource that covers this and many other macOS virtualization projects.
*   Removed `macOS for all computers`.
    *   **Reason:** promotes pre-built EFIs, which are heavily discouraged by the Hackintosh community. they often lead to instability and prevent users from learning how to properly configure their system.
*   Removed `Tonymacx86` / `Olarilla`.
    *   **Reason:** removed because they promote outdated and less reliable methods (UniBeast/MultiBeast). the community standard has moved to the OpenCore method taught by the `Dortania` guide, which is more stable.

**Other Changes:**

*   Added a tip underneath the Hackintosh section.

***

### LaTeX Tools

**Category Change:**

*   Moved `LaTeX Tools` from *Storage* under *Text Tools*.

**Site Removals:**

*   Removed `Gilles Castel` & `Tips for Writing a Research Paper using LaTeX`.
    *   **Reason:** removed because `Learn LaTeX` is a more structured and comprehensive learning resource, whereas these are more akin to blog posts.
*   Removed `Papeeria`.
    *   **Reason:** removed as a less common alternative to `Overleaf` and `TeXStudio`, which are the leading editors for online and desktop use.
*   Removed `R Markdown`.
    *   **Reason:** niche. it's primarily used within the R programming and data science communities, not as a general LaTeX alternative like `Typst`.
*   Removed `Quick LaTeX`, `SimpleTex`, `Math Scan`, `RapidLatexOCR`.
    *   **Reason:** removed for redundancy. `LaTeX-OCR` is the most popular and effective tool for image-to-LaTeX conversion. basic image generation is a standard feature in modern editors like `Overleaf`.

**Other Changes:**

*   Starred `Overleaf`.
    *   **Reason:** accessible from any device with an internet browser, good ui, has a good community reputation, free tier offers unlimited projects.