### PR TITLE
chore: add toolkitvault.com uuid generator

### DIFF
--- a/docs/developer-tools.md
+++ b/docs/developer-tools.md
@@ -139,6 +139,7 @@
 * [minisign](https://jedisct1.github.io/minisign/) - Sign Files / Verify Digital Signatures / [GitHub](https://github.com/jedisct1/minisign)
 * [VirtualBuddy](https://github.com/insidegui/VirtualBuddy) - Virtualize macOS 12 and later on Apple Silicon
 * [Pencil](https://pencil.evolus.vn/) - Software Mockup Tool / [GitHub](https://github.com/evolus/pencil)
+* [Free UUID Generator (All Versions)](https://toolkitvault.com/uuid-generator) - Free Public UUID Generator API / [Docs](https://toolkitvault.com/uuid-generator/uuid-api-docs)
 
 ***
 


### PR DESCRIPTION
I am adding a very useful tool for any developer that needs a fast secure tool for UUID Generation.

Alongside in-browser UUID Generation, this tool also provides a free public API which description follows:

A fast, free, public UUID Generator REST API that returns clean JSON over HTTPS, supporting v1, v3, v4, v5, v6, and time-ordered v7 (with guid as a v4 alias).

Generate bulk UUIDs (up to 200 per call) via simple GET endpoints, use namespace/name hashing for v3/v5 (dns/url), and optional output formatting (uppercase/braced).

No auth, needed.