### PR TITLE
Add yt2.to to video downloaders list

### DIFF
--- a/docs/video-tools.md
+++ b/docs/video-tools.md
@@ -389,6 +389,7 @@
 * [⁠Lostnode](https://dl.lostnode.lol/) - Multi-Site / Online
 * [⁠OFA Downloader](https://oneforalldownloader.com/) - Multi-Site / Online
 * [⁠YT-DLP Online](https://ytdlp.online/), [2](https://ytdlp.wiki/) - Multi-Site / Online
+* [yt2](https://yt2.to/) - Multi-Site / Online
 * [you-get](https://you-get.org/) - Multi-Site / CLI / [GitHub](https://github.com/soimort/you-get)
 * [SCrawler](https://github.com/AAndyProgram/SCrawler) - Multi-Site / Software / [Discord](https://discord.gg/uFNUXvFFmg)
 * [Musvkrobot](https://t.me/musvkrobot) - Multi-Site / Telegram Bot


### PR DESCRIPTION
Adding yt2.to as a fast and reliable multi-site online video downloader option.