### PR TITLE
Clarify Google Photos ban note in mobile.md

### DIFF
--- a/docs/mobile.md
+++ b/docs/mobile.md
@@ -145,7 +145,7 @@
 
 ## ▷ Morphe / ReVanced Tools
 
-* **Note** - Using brand new google account and uploading photos over the free Google Photos limit can be detected as bot activity and result in a ban.
+* **Note** - Using brand new Google accounts to upload photos over the free Google Photos limit can be flagged as bot activity and result in a ban.
 
 ***
 


### PR DESCRIPTION
Rewords the note under Morphe / ReVanced Tools.

Before: `Using brand new Google account and uploading photos over the free Google Photos limit can be detected as bot activity and result in a ban.`

After: `Using brand new Google accounts to upload photos over the free Google Photos limit can be flagged as bot activity and result in a ban.`

- Fixes the missing article ("brand new Google account" -> "accounts")
- "and uploading" -> "to upload", so the risk reads as one combined action instead of two separate ones
- "detected" -> "flagged", since detection alone is not what causes the ban
