### PR TITLE
Add XMLable to Markup tools

### DIFF
--- a/docs/text-tools.md
+++ b/docs/text-tools.md
@@ -467,6 +467,7 @@
 * [Quartz](https://quartz.jzhao.xyz/), [Perlite](https://perlite.secure77.de/) or [FlowerShow](https://flowershow.app/) - Publish Markdown
 * [Markdown Tutorial](https://www.markdowntutorial.com/) - Interactive Markdown Tutorial
 * [emoji-cheat-sheet](https://github.com/ikatyang/emoji-cheat-sheet) - Emoji Markdown Cheatsheet
+* [XMLable](https://xmlable.com/) - Online XML Tools
 
 ***
 


### PR DESCRIPTION
Added XMLable (https://xmlable.com/), an online XML tools (XML comparator, formatter, validator, generator, Xpath tester, converters...) that I maintain.