### PR TITLE
add The Podcast App to Podcast Streaming

### DIFF
--- a/docs/audio.md
+++ b/docs/audio.md
@@ -152,6 +152,7 @@
 * [BBC Podcasts](https://www.bbc.co.uk/sounds/podcasts) / [Downloader](https://github.com/get-iplayer/get_iplayer)
 * [Player FM](https://player.fm/)
 * [Podcast Republic](https://www.podcastrepublic.net/)
+* [The Podcast App](https://thepodcastapp.dev/) - Podcasts / Android & iOS / [RSS Validator](https://thepodcastapp.dev/tools/rss-validator)
 * [Relay.fm](https://www.relay.fm/)
 * [podcast-dl](https://github.com/lightpohl/podcast-dl), [PodcastBulkDownloader](https://github.com/cnovel/PodcastBulkDownloader), [PodDL](https://github.com/freshe/poddl) or [PodGrab](https://github.com/akhilrex/podgrab) - Podcast Downloaders
 * [PodScripts](https://podscripts.co/) - Podcast Transcript Search


### PR DESCRIPTION
Adds **The Podcast App** to `docs/audio.md` → ▷ Podcast Streaming, alongside the other
players already listed there (Player FM, Podcast Republic, Pocket Casts).

**Disclosure: I work on The Podcast App.** Happy to close this if you'd rather the entry
came from a user, or to adjust the wording/placement to fit your conventions.

Why I think it fits the section:

- **Free core listening, no trial wall** — subscribing, downloads, queue, playback speed and
  sleep timer are all free. There is an optional Premium tier for AI features, but nothing in
  the core listening experience is time-limited or paywalled, so it should clear the
  "no paid / trial-only entries" rule. (Pocket Casts, listed above, is freemium on the same
  basis.)
- **No app-inserted ads.**
- **Open ecosystem** — subscribe by RSS to any public feed, OPML import/export, no account
  required to listen.
- Android & iOS.

I also linked the free [RSS feed validator](https://thepodcastapp.dev/tools/rss-validator)
since it is a no-login web tool and the kind of thing this wiki tends to find useful — happy
to drop that half of the entry if you'd prefer just the app link.
