### PR TITLE
Add Remote Frontend Jobs and Remote Backend Jobs

### DIFF
--- a/docs/misc.md
+++ b/docs/misc.md
@@ -982,6 +982,8 @@
 * [Remotive](https://remotive.com/) - Remote Jobs
 * [DailyRemote](https://dailyremote.com/) - Remote Jobs
 * [HireBasis](https://www.hirebasis.com/) - Remote Jobs
+* [Remote Frontend Jobs](https://remotefrontendjobs.com/) - Remote Frontend Jobs
+* [Remote Backend Jobs](https://remotebackendjobs.com/) - Remote Backend Jobs
 
 ***
 
@@ -1002,6 +1004,8 @@
 * [r/DesignJobs](https://www.reddit.com/r/DesignJobs/) - Designer Jobs Subreddit
 * [Best PM Jobs](https://www.bestpmjobs.com/) - Tech Firm Night Jobs
 * [JS Remotely](https://jsremotely.com/) - Find Remote JavaScript Jobs
+* [Remote Frontend Jobs](https://remotefrontendjobs.com/) - Find Remote Frontend Jobs
+* [Remote Backend Jobs](https://remotebackendjobs.com/) - Find Remote Backend Jobs
 * [larajobs](https://larajobs.com/) - Find Laravel Jobs
 * [Python Job Board](https://www.python.org/jobs/) - Find Python Jobs
 * [Levels.fyi](https://www.levels.fyi/) - Tech Career Salaries


### PR DESCRIPTION
Add https://remotefrontendjobs.com and https://remotebackendjobs.com to Remote Jobs and Tech Jobs sections in docs/misc.md

Title: Add Remote Frontend Jobs and Remote Backend Jobs

### Disclosure
Owner/operator of both sites — self-submission per CONTRIBUTING.md:37-38.

### Sites
- https://remotefrontendjobs.com — Remote frontend aggregator (24 sources, free browse)
- https://remotebackendjobs.com — Remote backend aggregator (24 sources, free browse)
Verified live 2026-08-31, no paywall, no trial required to view jobs.