### PR TITLE
Add back SmokeAPI to gaming-tools.md

### DIFF
--- a/docs/gaming-tools.md
+++ b/docs/gaming-tools.md
@@ -357,6 +357,7 @@
 
 ## ▷ DLC Unlock / DRM Bypass
 
+* ⭐ **[SmokeAPI](https://github.com/acidicoala/SmokeAPI)** - Steam DLC Unlocker
 * ⭐ **[CreamAPI](https://cs.rin.ru/forum/viewtopic.php?t=70576)** - Steam DLC Unlocker
 * ⭐ **[GreenLuma](https://cs.rin.ru/forum/viewtopic.php?f=29&t=103709)** - Steam DLC Unlocker / [Manager](https://github.com/3vil3vo/GreenLuma-Manager)
 * ⭐ **[⁠SteaMidra](https://github.com/Midrags/SFF)** - Steam Game Unlocker w/ Multitool, DLC Unlockers + Auto Online Fix


### PR DESCRIPTION
SmokeAPI was originally removed from FMHY in #2534 because the store mode was no longer working and detected by Steam. Store mode was a way to inject into Steam itself to unlock DLCs, instead of injecting into every game individually.
acidicola has since updated SmokeAPI and removed the store mode in [v3.0.0](https://github.com/acidicoala/SmokeAPI/releases/tag/v3.0.0). He also posted [a more detailed explanation](https://cs.rin.ru/forum/viewtopic.php?p=3346006#p3346006)

There's been some other useful updates to SteamAPI that are worth mentioning:
- Added support for unlocking DLCs in native linux games
- Added a new "self-hook" mode that makes use of DLL search order hijacking (rename SmokeAPI to version.dll, winhttp.dll or winmm.dll and the game will load that DLL instead of the original one from System32)
- Added support for new Steamworks SDK versions

I think it makes sense to put SmokeAPI at the very top of the DLC unlock section, since it's open source (unlike CreamAPI, afaik), not AI slop, has been around for a while, and was created by a well-known community member.
