### PR TITLE
Add Numeros to Multi Tool Sites

### DIFF
--- a/docs/misc.md
+++ b/docs/misc.md
@@ -1376,6 +1376,7 @@
 * 🌐 **[Mr Free Tools](https://mrfreetools.com/)** - Find Free Tools
 * ⭐ **[TinyWow](https://tinywow.com/)** - Text / Image / PDF / File
 * ⭐ **[PineTools](https://pinetools.com/)** - Text / Multimedia / Colors / Code
+* [⁠Numeros](https://www.numeros.pro/) - Financial / Business / Math / Health Calculators
 * [⁠Ou0.cc](https://ou0.cc/) - Text / Social Media / Code / Multimedia
 * [GoOnlineTools](https://goonlinetools.com/) - Text / Encode-Decode / Code / Random / Image
 * [⁠99Tools](https://99tools.net/) - Text / Encode-Decode / Code / Random / Image


### PR DESCRIPTION
Numeros.pro — free multi-category calculator site (400+ tools: financial, business, math, health & more). Every calculator shows its formula and a worked example, no sign-up, and everything runs in the browser.

Fits the Multi Tool Sites section alongside similar all-in-one tool sites.