### PR TITLE
Added BackRankChess, BrokenLinkRecovery and Calc84Online

### DIFF
--- a/docs/educational.md
+++ b/docs/educational.md
@@ -1858,6 +1858,7 @@
 * [⁠Numla](https://numla.app/) / [GitHub](https://github.com/davidesantangelo/numla) or [Math Notepad](https://mathnotepad.com/) - Live Calculative Notepads
 * [PhotoMath](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/android#wiki_.25B7_modded_apks) (search), [Mathway](https://www.mathway.com/), [MathDF](https://mathdf.com/), [Tiger Algebra](https://www.tiger-algebra.com/), [⁠Maxima](https://maxima.sourceforge.io/) or [Symbolab](https://www.symbolab.com/) - Math / Algebra Problem Solvers
 * [⁠CalcPlex](https://calcplex.com/) - Graphing Calculator Guides 
+* [TICalc](http://calc84online.com/) - TI Graphing Calculators
 
 ***
 

--- a/docs/educational.md
+++ b/docs/educational.md
@@ -1858,7 +1858,7 @@
 * [⁠Numla](https://numla.app/) / [GitHub](https://github.com/davidesantangelo/numla) or [Math Notepad](https://mathnotepad.com/) - Live Calculative Notepads
 * [PhotoMath](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/android#wiki_.25B7_modded_apks) (search), [Mathway](https://www.mathway.com/), [MathDF](https://mathdf.com/), [Tiger Algebra](https://www.tiger-algebra.com/), [⁠Maxima](https://maxima.sourceforge.io/) or [Symbolab](https://www.symbolab.com/) - Math / Algebra Problem Solvers
 * [⁠CalcPlex](https://calcplex.com/) - Graphing Calculator Guides 
-* [TICalc](http://calc84online.com/) - TI Graphing Calculators
+* [Calc84Online](http://calc84online.com/) - TI Graphing Calculators
 
 ***
 

--- a/docs/gaming.md
+++ b/docs/gaming.md
@@ -662,6 +662,7 @@
 * [The Kilobyte's Gambit](https://vole.wtf/kilobytes-gambit/) - Retro-Style Chess
 * [Chesses](https://pippinbarr.com/chesses/), [TheChessDirectory](https://thechessdirectory.com/play-chess) or [Omnichess](https://omnichess.club/) - Multiple Styles of Chess
 * [Print Chess](https://www.printchess.com/) - Printable Paper Chess Set
+* [Back Rank Chess](http://playbackrankchess.com/) - Arrange your pieces in home rank
 
 ***
 

--- a/docs/internet-tools.md
+++ b/docs/internet-tools.md
@@ -857,6 +857,7 @@
 * [WebArchive.io](https://www.webarchive.io/) - Archive Web Pages
 * [ArchiveTeam](https://wiki.archiveteam.org/index.php/Main_Page) - Archiving Project / Wiki / Full Site Archive
 * [Perma.cc](https://perma.cc/) - Create Permalinks
+* [Broken Link Recovery](https://brokenlinkrecovery.com/) - A lightweight client built on top of the Web Archive
 
 ***
 


### PR DESCRIPTION
### Summary of Changes
Added three new tools across Educational, Gaming, and Internet Tools sections:
- **[Calc84Online](http://calc84online.com/)** - TI Graphing Calculators (`docs/educational.md` under *Calculators*)
- **[Back Rank Chess](http://playbackrankchess.com/)** - Arrange your pieces in home rank (`docs/gaming.md` under *Chess*)
- **[Broken Link Recovery](https://brokenlinkrecovery.com/)** - A lightweight client built on top of the Web Archive (`docs/internet-tools.md` under *Archive Services*)