### PR TITLE
Add platform labels to terminal and package managers, add docker icon

### DIFF
--- a/docs/.vitepress/transformer.ts
+++ b/docs/.vitepress/transformer.ts
@@ -348,6 +348,12 @@ const transformLinks = (text: string): string =>
         find: /(?<=\/ (\/>|[^/\r\n])*)(,\s)?(?<![a-z]\s)Web(?=,|[ \t]\/|$)/gm,
         replace:
           ' <span v-tooltip="\'Web\'" alt="Web" class="i-fluent:globe-32-filled" /> '
+      },
+      {
+        name: 'Docker',
+        find: /(?<=\/ (\/>|[^/\r\n])*)(,\s)?(?<![a-z]\s)Docker(?=,|[ \t]\/|$)/gm,
+        replace:
+          ' <span v-tooltip="\'Docker\'" alt="Docker" class="i-simple-icons:docker inline-block w-3em h-3em align-middle" /> '
       }
     ])
     .getText()

--- a/docs/system-tools.md
+++ b/docs/system-tools.md
@@ -89,14 +89,14 @@
 
 ## ▷ Task Automation
 
-* ⭐ **[AutoHotkey](https://www.autohotkey.com/)** / [Resources](https://github.com/ahkscript/awesome-AutoHotkey) / [Discord](https://discord.com/invite/Aat7KHmG7v) / [GitHub](https://github.com/AutoHotkey/AutoHotkey)
-* [Scheduler](https://www.splinterware.com/products/scheduler.html), [⁠FluentTaskScheduler](https://github.com/TRGamer-tech/FluentTaskScheduler) or [TaskRunner](https://www.keyefficiency.com/) - System Task Scheduler
-* [AutoIt](https://www.autoitscript.com/)
-* [Tinytask](https://tinytask.net/)
-* [sikulix](http://sikulix.com/)
-* [ChoEazyCopy](https://github.com/Cinchoo/ChoEazyCopy)
-* [MacroRecorder](https://www.macrorecorder.com/)
-* [Organize](https://organize.readthedocs.io) - Automated File Manager / [GitHub](https://github.com/tfeldmann/organize)
+* ⭐ **[AutoHotkey](https://www.autohotkey.com/)** / [Resources](https://github.com/ahkscript/awesome-AutoHotkey) / [Discord](https://discord.com/invite/Aat7KHmG7v) / Windows / [GitHub](https://github.com/AutoHotkey/AutoHotkey)
+* [Scheduler](https://www.splinterware.com/products/scheduler.html), [⁠FluentTaskScheduler](https://github.com/TRGamer-tech/FluentTaskScheduler) or [TaskRunner](https://www.keyefficiency.com/) - System Task Scheduler / Windows
+* [AutoIt](https://www.autoitscript.com/) / Windows
+* [Tinytask](https://tinytask.net/) / Windows
+* [OculiX](https://oculix.org/) / Windows, macOS, Linux / [GitHub](https://github.com/oculix-org/Oculix)
+* [ChoEazyCopy](https://github.com/Cinchoo/ChoEazyCopy) / Windows
+* [MacroRecorder](https://www.macrorecorder.com/) / Windows, macOS
+* [Organize](https://organize.readthedocs.io) - Automated File Manager / Windows, macOS, Linux, Docker / [GitHub](https://github.com/tfeldmann/organize)
 
 ***
 
@@ -104,20 +104,20 @@
 
 * 🌐 **[Awesome TUI](https://github.com/rothgar/awesome-tuis)** - TUI App Index
 * 🌐 **[⁠Awesome Terminals](https://github.com/cdleon/awesome-terminals)** - Terminal Emulator List
-* 🌐 **[terminals-are-sexy](https://terminalsare.sexy/)** - Terminal Resources
 * 🌐 **[Awesome CLI Apps](https://github.com/agarrharr/awesome-cli-apps)** or [Command Line Tools](https://github.com/learn-anything/command-line-tools) - Command Line Resources
 * ⭐ **[ss64](https://ss64.com/)** - Command Line Reference Index
-* [Windows Terminal](https://www.microsoft.com/store/productId/9N0DX20HK701) / [2](https://github.com/microsoft/terminal/), [Tabby](https://tabby.sh/) / [GitHub](https://github.com/eugeny/tabby), [MobaXterm](https://mobaxterm.mobatek.net/) or [WezTerm](https://wezfurlong.org/wezterm/) / [Plugins](https://github.com/michaelbrusegard/awesome-wezterm) / [GitHub](https://github.com/wezterm/wezterm) - Windows Terminal Emulators
-* [psmux](https://psmux.pages.dev/) (Windows Tmux) / [GitHub](https://github.com/psmux/psmux) or [Zellij](https://zellij.dev/) / [GitHub](https://github.com/zellij-org/zellij) - Terminal Multiplexers
+* [Windows Terminal](https://www.microsoft.com/store/productId/9N0DX20HK701) / [GitHub](https://github.com/microsoft/terminal/), [Tabby](https://tabby.sh/) / [GitHub](https://github.com/eugeny/tabby), [MobaXterm](https://mobaxterm.mobatek.net/) or [WezTerm](https://wezfurlong.org/wezterm/) / [Plugins](https://github.com/michaelbrusegard/awesome-wezterm) / [GitHub](https://github.com/wezterm/wezterm) - Terminal Emulators / Windows
+* [psmux](https://psmux.pages.dev/) - Windows Tmux / Windows / [GitHub](https://github.com/psmux/psmux) 
+* [Zellij](https://zellij.dev/) - Terminal Multiplexer / Windows, macOS, Linux / [GitHub](https://github.com/zellij-org/zellij)
 * [PowerShell](https://github.com/powershell/powershell) - Microsoft PowerShell / Windows, macOS, Linux
-* [BusyBox](https://frippery.org/busybox/) - Unix Commands for Windows / [GitHub](https://github.com/rmyorston/busybox-w32) / [GitLab](https://gitlab.com/rmyorston/busybox-w32)
-* [Clink](https://github.com/chrisant996/clink) - Command Line Editing
-* [Nushell](https://www.nushell.sh/) - Alt Shell / [GitHub](https://github.com/nushell/nushell)
-* [⁠procs](https://github.com/dalance/procs) - ps (Process Status) Replacement
-* [⁠WTF](https://wtfutil.com/) / [GitHub](https://github.com/wtfutil/wtf) - Terminal Dashboard
-* [Command Challenge](https://cmdchallenge.com/) - Command Line Learning
-* [Mintty](https://mintty.github.io/) - Cygwin Terminal Emulator
-* [GetDNote](https://www.getdnote.com/) - Command Line Notebook
+* [BusyBox](https://frippery.org/busybox/) - Unix Commands for Windows / Windows / [GitHub](https://github.com/rmyorston/busybox-w32) / [GitLab](https://gitlab.com/rmyorston/busybox-w32)
+* [Clink](https://github.com/chrisant996/clink) - Command Line Editing / Windows
+* [Nushell](https://www.nushell.sh/) - Alt Shell / Windows, macOS, Linux / [GitHub](https://github.com/nushell/nushell)
+* [⁠procs](https://github.com/dalance/procs) - ps (Process Status) Replacement / Windows, macOS, Linux
+* [⁠WTF](https://wtfutil.com/) - Terminal Dashboard / Windows, macOS, Linux, Docker / [GitHub](https://github.com/wtfutil/wtf)
+* [Command Challenge](https://cmdchallenge.com/) - Command Line Learning / Web
+* [Mintty](https://mintty.github.io/) - Cygwin Terminal Emulator / Windows
+* [GetDNote](https://www.getdnote.com/) - Command Line Notebook / Windows, macOS, Linux, Docker / [GitHub](https://github.com/dnote/dnote)
 * [LeanandMean](https://github.com/AveYo/LeanAndMean) - Powershell Snippets / Use with Caution
 * [PowerShell Scripts](https://github.com/fleschutz/PowerShell), [PowershellGallery](https://www.powershellgallery.com/) or [WindowsPowerShell](https://github.com/stevencohn/WindowsPowerShell) - Shell Scripts
 
@@ -422,7 +422,7 @@
 
 # ► Customization
 
-* 🌐 [Frutiger Aero Archive](https://frutigeraeroarchive.org/) or [Heliohost Guide](https://ninjasr.varesia.com/w/lb/windows) - Windows Customization Resources
+* 🌐 **[Frutiger Aero Archive](https://frutigeraeroarchive.org/)** or [Heliohost Guide](https://ninjasr.varesia.com/w/lb/windows) - Windows Customization Resources
 * ⭐ **[Rainmeter](https://www.rainmeter.net/)** / [Discord](https://discord.com/invite/rainmeter) or [⁠Seelen UI](https://github.com/eythaann/Seelen-UI) / [Discord](https://discord.gg/ABfASx5ZAJ) - Desktop Customization Environments
 * ⭐ **[OpenRGB](https://openrgb.org/)**, **[WLED](https://kno.wled.ge/)**, [Aurora](https://www.project-aurora.com/), [LiquidCTL](https://github.com/liquidctl/liquidctl), [Artemis](https://artemis-rgb.com/) or [FireLight](https://github.com/nicolasdeory/firelight) - RGB Lighting Control
 * ⭐ **[VSThemes](https://vsthemes.org/en/)**, [WindowsCustomization](https://windowscustomization.com/) or [7Themes](https://7themes.su/) - Theme Collections

--- a/unocss.config.ts
+++ b/unocss.config.ts
@@ -52,6 +52,8 @@ export default defineConfig({
     'i-qlementine-icons:windows-24',
     'i-simple-icons:ios',
     'i-simple-icons:torbrowser',
+    'i-simple-icons:docker',
+    'i-logos:docker-icon',
     'h-1em',
     'w-1em',
     'text-4xl',


### PR DESCRIPTION
Added the docker icon the list of conversions, now we can add Docker alongside windows, macOS, Linux labels